### PR TITLE
OWENSFEA triage hardening bundle

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -37,7 +37,9 @@ jobs:
           repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
           path: downstream
       - name: Workaround Pkg.jl bug
-        run: sed -i -e 's/^OWENSFEA = {.*}//' downstream/Project.toml
+        run: |
+          sed -i -e 's/^OWENSFEA = {.*}//' downstream/Project.toml
+          sed -i -e '/^\[sources\.OWENSFEA\]$/,+1d' downstream/Project.toml
       - name: Load this and run the downstream tests
         shell: julia --project=downstream {0}
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /Manifest.toml
 *.DS_Store
+*.cov
 */figs/*
 *.vtu
 *.pvd

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 /Manifest.toml
+*/Manifest.toml
 *.DS_Store
 *.cov
 */figs/*
+docs/build/
 *.vtu
 *.pvd
 *.pdf

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,8 +2,12 @@
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
+OWENSFEA = "5906b1e7-6737-4278-91ec-d653c88addb4"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
+
+[sources]
+OWENSFEA = {path = ".."}
 
 [extras]
 CPUSummary = "2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,10 +5,15 @@ makedocs(;
     modules = [OWENSFEA],
     pages = [
         "Home" => "index.md",
+        "Quickstart" => "quickstart.md",
+        "Model Assembly" => "model_assembly.md",
+        "Theory, Frames, and Units" => joinpath("theory", "frames_units.md"),
+        "Validation and Testing" => "validation.md",
         "API Reference" => joinpath("reference", "reference.md"),
     ],
     sitename = "OWENSFEA.jl",
     authors = "Kevin R. Moore <kevmoor@sandia.gov>",
+    remotes = nothing,
 )
 
 deploydocs(

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,8 +14,15 @@ makedocs(;
     sitename = "OWENSFEA.jl",
     authors = "Kevin R. Moore <kevmoor@sandia.gov>",
     remotes = nothing,
+    format = Documenter.HTML(
+        repolink = "https://github.com/sandialabs/OWENSFEA.jl",
+        edit_link = "master",
+    ),
 )
 
-deploydocs(
-    repo = "github.com/sandialabs/OWENSFEA.jl.git",
-)
+if get(ENV, "CI", "false") == "true"
+    deploydocs(
+        repo = "github.com/sandialabs/OWENSFEA.jl.git",
+        devbranch = "master",
+    )
+end

--- a/docs/src/assets/fea_workflow.svg
+++ b/docs/src/assets/fea_workflow.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 260" role="img" aria-label="OWENSFEA structural workflow">
+  <defs>
+    <style>
+      .box{fill:#f8fbff;stroke:#255f85;stroke-width:2;rx:10}
+      .core{fill:#fff8ee;stroke:#9a6b1f;stroke-width:2;rx:10}
+      .text{font-family:Arial,Helvetica,sans-serif;font-size:20px;fill:#17212b}
+      .small{font-size:15px;fill:#394b59}
+      .arrow{stroke:#255f85;stroke-width:3;fill:none;marker-end:url(#arrow)}
+    </style>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#255f85"/>
+    </marker>
+  </defs>
+  <rect class="box" x="28" y="72" width="155" height="92"/>
+  <text class="text" x="61" y="110">Mesh</text>
+  <text class="small" x="51" y="136">nodes, elements,</text>
+  <text class="small" x="63" y="154">orientations</text>
+  <path class="arrow" d="M183 118 H245"/>
+  <rect class="box" x="245" y="72" width="170" height="92"/>
+  <text class="text" x="279" y="110">Sections</text>
+  <text class="small" x="272" y="136">EA, EI, GJ, mass,</text>
+  <text class="small" x="291" y="154">offsets</text>
+  <path class="arrow" d="M415 118 H480"/>
+  <rect class="core" x="480" y="54" width="190" height="128"/>
+  <text class="text" x="515" y="101">FEAModel</text>
+  <text class="small" x="508" y="128">BCs, joints, loads,</text>
+  <text class="small" x="520" y="148">solver options</text>
+  <path class="arrow" d="M670 118 H735"/>
+  <rect class="box" x="735" y="72" width="155" height="92"/>
+  <text class="text" x="768" y="110">Solve</text>
+  <text class="small" x="760" y="136">modal, steady,</text>
+  <text class="small" x="771" y="154">transient</text>
+  <path class="arrow" d="M575 182 V226 H107 V164"/>
+  <text class="small" x="266" y="245">displacements, strains, reactions, updated state</text>
+</svg>

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,7 +1,38 @@
 # OWENSFEA
 
-OWENSFEA is a structural dynamics analysis tool intended to address the challenges associated with modeling Vertical Axis Wind Turbines (VAWTs), namely spin softening, centrifugal stiffening, and coriolis forces, in a numerically energy preserving finite element method.  This finite element method is based on the Timoshenko beam element and can be run both for modal and unsteady analyses. Please see the following reference for more details.
+OWENSFEA is the structural dynamics package in the OWENS toolkit. It provides
+beam finite-element models used for turbine blades, struts, towers, and coupled
+aeroelastic simulations. The code supports modal, nonlinear steady, transient,
+and reduced-order structural workflows.
 
-Please make all feature changes and bug fixes as branches and then create pull requests against the dev branch.  The dev branch will be periodically pulled into master for version changes.
+```@raw html
+<p align="center">
+    <img src="./assets/fea_workflow.svg" alt="OWENSFEA workflow diagram" style="width:72%">
+</p>
+```
 
- Owens,B.C.,“Theoretical Developments and Practical Aspects of Dynamic Systems in Wind Energy Applications,”Ph.D. thesis, Texas A & M University, 2013. URL http://hdl.handle.net/1969.1/151813.
+The package is based on a Timoshenko beam formulation and the dynamic-system
+work described in:
+
+Owens, B. C., "Theoretical Developments and Practical Aspects of Dynamic Systems
+in Wind Energy Applications," Ph.D. thesis, Texas A & M University, 2013.
+
+## What This Package Owns
+
+- structural mesh, element, section-property, and FEA model types;
+- joint constraints, prescribed boundary conditions, and concentrated nodal
+  terms;
+- element stiffness, mass, damping, gravity, spin, and follower-load
+  calculations;
+- linear modal analysis, nonlinear steady solve, transient dynamics, and ROM
+  utilities;
+- structural reactions, strains, and post-solve helper maps used by OWENS.
+
+## Where To Start
+
+- Use the quickstart for a minimal model and test-backed workflow references.
+- Use model assembly before changing meshes, joints, boundary conditions, or
+  concentrated terms.
+- Use the frames and units page before comparing against GXBeam, OpenFAST, or
+  experimental data.
+- Use the validation page before changing solver tolerances or reference data.

--- a/docs/src/model_assembly.md
+++ b/docs/src/model_assembly.md
@@ -25,8 +25,11 @@ center of mass before mapping into FEA inputs.
 
 When `GAy` and `GAz` are omitted, the Timoshenko element computes both
 transverse shear stiffnesses from `EA`, Poisson's ratio 0.3, and a 5/6 shear
-correction. Composite or externally generated section-property workflows should
-pass explicit `GAy` and `GAz` values when available.
+correction unless `poisson_ratio` or `shear_correction` arrays are supplied on
+the section properties. Composite or externally generated section-property
+workflows should pass explicit `GAy` and `GAz` values when available; otherwise
+they should pass the material Poisson ratio and shear-correction factor used to
+derive the transverse shear stiffnesses.
 
 ## Boundary Conditions
 

--- a/docs/src/model_assembly.md
+++ b/docs/src/model_assembly.md
@@ -1,0 +1,68 @@
+# Model Assembly
+
+This page documents the contracts that are easiest to break during refactors.
+
+## Mesh And Elements
+
+`Mesh` stores node coordinates, element connectivity, element types, mesh
+segments, and optional structural blade/tower indexing. `El` stores element-level
+properties and distributed loads. Keep node ordering and element orientation
+stable because those choices define local beam frames and reaction signs.
+
+## Section Properties
+
+`SectionPropsArray` carries spanwise structural properties:
+
+- `EA`, `GJ`, `EIyy`, `EIzz`, and optional coupling terms;
+- mass per unit length and inertias;
+- center-of-mass and aerodynamic-center offsets;
+- twist and aerodynamic/structural reference offsets.
+
+When section data comes from `OWENSPreComp`, document whether offsets are
+relative to the leading edge, reference axis, shear center, tension center, or
+center of mass before mapping into FEA inputs.
+
+## Boundary Conditions
+
+Boundary conditions are expressed as node number, local DOF number, and
+prescribed value. Utility tests pin the reduced DOF map and static boundary
+condition application. A constrained DOF should either be removed from the solve
+or assigned the prescribed value consistently in the full displacement vector.
+
+## Joints
+
+Joint rows use this contract:
+
+| Column | Meaning |
+| --- | --- |
+| 1 | joint number |
+| 2 | master node |
+| 3 | slave node |
+| 4 | joint type |
+| 5 | joint mass or rigid-bar `lx`, depending on context |
+| 6 | rigid-bar `ly` |
+| 7 | rigid-bar `lz` or `psi`, depending on context |
+| 8 | `theta` |
+
+Joint types currently covered by unit tests:
+
+- `0`: fixed/welded;
+- `1`: pinned translational constraint;
+- `2`: hinge along local 2 axis;
+- `3`: hinge along local 1 axis;
+- `4`: hinge along local 3 axis;
+- `5`: rigid-bar constraint.
+
+The rigid-bar path couples slave translations to master rotations through the
+bar offset. Tests pin this transform because sign mistakes directly affect
+reaction forces.
+
+## Concentrated Terms
+
+`applyConcentratedTerms` parses concentrated mass, stiffness, damping, and load
+terms into global arrays. Four-column rows apply diagonal terms, while
+five-column rows specify a row/column DOF pair. Loads are one-dimensional and
+ignore the second DOF in five-column input.
+
+Use temporary files for parser tests and prefer direct `data = ...` input for
+unit tests that only need to pin matrix assembly.

--- a/docs/src/model_assembly.md
+++ b/docs/src/model_assembly.md
@@ -13,7 +13,8 @@ stable because those choices define local beam frames and reaction signs.
 
 `SectionPropsArray` carries spanwise structural properties:
 
-- `EA`, `GJ`, `EIyy`, `EIzz`, and optional coupling terms;
+- `EA`, `GJ`, `EIyy`, `EIzz`, optional transverse shear stiffnesses
+  `GAy`/`GAz`, and optional coupling terms;
 - mass per unit length and inertias;
 - center-of-mass and aerodynamic-center offsets;
 - twist and aerodynamic/structural reference offsets.
@@ -21,6 +22,11 @@ stable because those choices define local beam frames and reaction signs.
 When section data comes from `OWENSPreComp`, document whether offsets are
 relative to the leading edge, reference axis, shear center, tension center, or
 center of mass before mapping into FEA inputs.
+
+When `GAy` and `GAz` are omitted, the Timoshenko element computes both
+transverse shear stiffnesses from `EA`, Poisson's ratio 0.3, and a 5/6 shear
+correction. Composite or externally generated section-property workflows should
+pass explicit `GAy` and `GAz` values when available.
 
 ## Boundary Conditions
 

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -1,0 +1,58 @@
+# Quickstart
+
+OWENSFEA workflows are easiest to debug when mesh, sections, boundary
+conditions, and loads are assembled explicitly. The cantilever tests provide the
+smallest maintained examples:
+
+- `test/CantileverBeamModal.jl` for modal analysis;
+- `test/CantileverBeamDisplacement.jl` for nonlinear/static displacement;
+- `test/UnsteadyBeam.jl` for transient dynamics and GXBeam comparison;
+- `test/HelperFunctions.jl` for joint, boundary-condition, and nodal-term
+  utility contracts.
+
+## Install
+
+```julia
+using Pkg
+Pkg.add(PackageSpec(url = "https://github.com/sandialabs/OWENSFEA.jl.git"))
+```
+
+For local toolkit development:
+
+```julia
+using Pkg
+Pkg.develop(path = ".")
+Pkg.instantiate()
+```
+
+The docs project uses local package sources and should be built with Julia 1.11
+or newer.
+
+## Minimal Structural Workflow
+
+1. Build or read a `Mesh`.
+2. Build an `El` object containing element-level material and section data.
+3. Create a `FEAModel` with analysis type, boundary conditions, joint data, and
+   solver options.
+4. Run the desired analysis path: modal, steady, unsteady, or ROM.
+5. Check displacement, strain, reaction, and modal outputs in the expected frame.
+
+The package exports selected utilities, but the high-level model types are often
+used through qualified names:
+
+```julia
+import OWENSFEA
+
+fea = OWENSFEA.FEAModel(; analysisType = "M", numNodes = 2)
+```
+
+## First Checks
+
+Before trusting a result:
+
+- confirm the mesh has six structural degrees of freedom per node;
+- verify constrained DOF maps and joint transforms;
+- verify section properties are in SI units;
+- check whether rotations are radians internally or degrees in a file;
+- compare reactions and displacement signs against a hand calculation for a
+  single-load case.

--- a/docs/src/theory/frames_units.md
+++ b/docs/src/theory/frames_units.md
@@ -1,0 +1,44 @@
+# Theory, Frames, and Units
+
+## Beam Coordinates
+
+OWENSFEA uses six degrees of freedom per node: three translations and three
+rotations. Element-level stiffness, mass, and load terms are assembled in local
+beam coordinates and mapped into the global system through element orientation
+data.
+
+## Units
+
+Use SI units unless a file format explicitly states otherwise:
+
+| Quantity | Unit |
+| --- | --- |
+| length, displacement | m |
+| velocity | m/s |
+| acceleration | m/s^2 |
+| force | N |
+| moment | N m |
+| mass per unit length | kg/m |
+| rotational speed | rad/s |
+| bending stiffness | N m^2 |
+| torsional stiffness | N m^2 |
+| axial stiffness | N |
+
+## Rotations
+
+Internal rotations and angular velocities are in radians. Some mesh inputs,
+orientation helpers, and plots use degrees for readability; conversion should
+occur at the IO or plotting boundary.
+
+## Loads
+
+Structural loads may be nodal, distributed per unit length, follower loads, or
+generalized reduced-order loads. Validation tests should name the load category
+because the expected reaction sign and magnitude differ.
+
+## Gravity And Spin Terms
+
+`FEAModel` controls gravity, spin-up, nonlinear, and aeroelastic options.
+Spin-softening, centrifugal, and Coriolis effects depend on the selected analysis
+path. A structural-only test should state whether gravity and rotor speed are
+enabled.

--- a/docs/src/theory/frames_units.md
+++ b/docs/src/theory/frames_units.md
@@ -19,7 +19,7 @@ Use SI units unless a file format explicitly states otherwise:
 | force | N |
 | moment | N m |
 | mass per unit length | kg/m |
-| rotational speed | rad/s |
+| internal angular speed | rad/s |
 | bending stiffness | N m^2 |
 | torsional stiffness | N m^2 |
 | axial stiffness | N |
@@ -42,3 +42,10 @@ because the expected reaction sign and magnitude differ.
 Spin-softening, centrifugal, and Coriolis effects depend on the selected analysis
 path. A structural-only test should state whether gravity and rotor speed are
 enabled.
+
+The current public steady `staticAnalysis` scalar `Omega` and `OmegaDot` inputs
+are z-axis spin terms supplied in revolutions/s and revolutions/s^2. The
+Timoshenko element path converts them internally to rad/s and rad/s^2 before
+adding them to the element rigid-body angular state. Global x-axis spin for HAWT
+rotor-only motion still needs an explicit public frame/state owner before it can
+replace the scalar z-axis path.

--- a/docs/src/validation.md
+++ b/docs/src/validation.md
@@ -8,6 +8,12 @@ OWENSFEA has three useful test layers:
 | Static/modal beams | `test/CantileverBeam*.jl` | beam displacement, modal frequencies, rotations, and nonlinear/static behavior. |
 | Transient comparison | `test/UnsteadyBeam.jl` | time response compared with GXBeam for the maintained cantilever case. |
 
+The helper layer also pins an off-axis nonlinear selective-stiffness matrix from
+`calculateTimoshenkoElementNLSS`. That case is a regression guard for future
+strain-stiffening and nonlinear ROM work: it fixes the current direct-iteration
+matrix entries and requires unsupported Newton-Raphson calls to fail fast with a
+clear error instead of reaching undefined tangent-matrix state.
+
 ## Acceptance Rules
 
 - Pin exact matrix entries for utility functions.

--- a/docs/src/validation.md
+++ b/docs/src/validation.md
@@ -14,6 +14,12 @@ strain-stiffening and nonlinear ROM work: it fixes the current direct-iteration
 matrix entries and requires unsupported Newton-Raphson calls to fail fast with a
 clear error instead of reaching undefined tangent-matrix state.
 
+`test/SpinningBeamDiagnostics.jl` pins structural-only spin reactions before
+gyric or spin-softening equation changes. The cases include straight and
+eccentric beams under scalar z-axis spin acceleration. The eccentric case also
+documents the current root-moment gap: the x-force from the offset is present,
+while the reported spin-axis torque omits the corresponding `y^2` contribution.
+
 ## Acceptance Rules
 
 - Pin exact matrix entries for utility functions.

--- a/docs/src/validation.md
+++ b/docs/src/validation.md
@@ -1,0 +1,29 @@
+# Validation and Testing
+
+OWENSFEA has three useful test layers:
+
+| Layer | Test files | What is pinned |
+| --- | --- | --- |
+| Helper/API | `test/HelperFunctions.jl` | quadrature, shape functions, reduced DOF maps, joint transforms, concentrated terms, and boundary-condition application. |
+| Static/modal beams | `test/CantileverBeam*.jl` | beam displacement, modal frequencies, rotations, and nonlinear/static behavior. |
+| Transient comparison | `test/UnsteadyBeam.jl` | time response compared with GXBeam for the maintained cantilever case. |
+
+## Acceptance Rules
+
+- Pin exact matrix entries for utility functions.
+- Use physically named displacement, strain, reaction, and frequency channels in
+  solver tests.
+- State whether a test is a regression, a unit/API contract, or a validation
+  against another solver.
+- Keep generated modal matrices and output files ignored or written to a
+  temporary path.
+
+## Current Known Gaps
+
+- `steady.jl`, `intermediate.jl`, and parts of `timoshenko.jl` still have lower
+  coverage than the utility layer.
+- The transient GXBeam comparison reports large RMS differences for some
+  channels; those are regression diagnostics, not proof of close physical
+  agreement.
+- Several public-looking functions are unexported and need clearer docstrings
+  before the API should be considered stable.

--- a/src/modal.jl
+++ b/src/modal.jl
@@ -164,7 +164,7 @@ function autoCampbellDiagram(FEAinputs,mymesh,myel,system,assembly,sections;
 end
 
 """
-    modal(feamodel,mesh,el;Omega=0.0,displ=zeros(mesh.numNodes*6),OmegaStart=0.0,returnDynMatrices=false)
+    modal(feamodel,mesh,el;Omega=0.0,displ=zeros(mesh.numNodes*6),OmegaStart=0.0,returnDynMatrices=false,dynMatrixFilename="./linearized_matrices.mat")
 
 Modal analysis
 
@@ -176,6 +176,7 @@ Modal analysis
 * `displ::Array{<:float}`: zeros(mesh.numNodes*6) initial (warm start) displacements for each dof
 * `OmegaStart::float`: rotor speed (Hz) from previous analysis if stepping through various rotor speeds, may be useful in load stepping
 * `returnDynMatrices::Bool`: Flag to save linearized K/C/M matrices for the design
+* `dynMatrixFilename::String`: Output path used when `returnDynMatrices` is true
 
 # Outputs:
 * `freq::Array{<:float}`: sorted modal frequencies (Hz)
@@ -195,7 +196,18 @@ Modal analysis
 * `theta_z_90::Array{<:float}`: NnodesxNmodes out-of-phase mode shape rotation about z
 
 """
-function modal(feamodel,mesh,el;Omega=0.0,displ=zeros(mesh.numNodes*6),OmegaStart=0.0,returnDynMatrices=false,elStorage=nothing,predef=nothing)
+function modal(
+    feamodel,
+    mesh,
+    el;
+    Omega = 0.0,
+    displ = zeros(mesh.numNodes*6),
+    OmegaStart = 0.0,
+    returnDynMatrices = false,
+    dynMatrixFilename = "./linearized_matrices.mat",
+    elStorage = nothing,
+    predef = nothing,
+)
 
     if elStorage===nothing
         elStorage = initialElementCalculations(feamodel,el,mesh) #performs initial element calculations
@@ -214,7 +226,7 @@ function modal(feamodel,mesh,el;Omega=0.0,displ=zeros(mesh.numNodes*6),OmegaStar
     if staticAnalysisSuccessful
         freq,damp,imagCompSign,U_x_0,U_y_0,U_z_0,theta_x_0,theta_y_0,theta_z_0,U_x_90,
         U_y_90,U_z_90,theta_x_90,theta_y_90,theta_z_90,eigVal,eigVec= linearAnalysisModal(feamodel,
-        mesh,el,displ,Omega,elStorage;returnDynMatrices,predef) #performs modal analysis
+        mesh,el,displ,Omega,elStorage;returnDynMatrices,dynMatrixFilename,predef) #performs modal analysis
     else
         error("Static analysis unsuccessful. Exiting")
     end
@@ -225,7 +237,17 @@ end
 """
 Internal, see ?modal
 """
-function  linearAnalysisModal(feamodel,mesh,el,displ,Omega,elStorage;returnDynMatrices=false,predef=nothing)
+function  linearAnalysisModal(
+    feamodel,
+    mesh,
+    el,
+    displ,
+    Omega,
+    elStorage;
+    returnDynMatrices = false,
+    dynMatrixFilename = "./linearized_matrices.mat",
+    predef = nothing,
+)
 
     feamodel.analysisType = "M" #Force type to align with the modal call
     elementOrder = feamodel.elementOrder  #extract element order from feamodel
@@ -268,7 +290,8 @@ function  linearAnalysisModal(feamodel,mesh,el,displ,Omega,elStorage;returnDynMa
         MgTotalU,_ = applyBC(Mg_con,zeros(length(Mg[:,1])),feamodel.BC,numDOFPerNode)
         CgTotalU,_ = applyBC(Cg_con,zeros(length(Cg[:,1])),feamodel.BC,numDOFPerNode)
 
-        filename = "./linearized_matrices.mat"
+        filename = dynMatrixFilename
+        mkpath(dirname(abspath(filename)))
         println("Saving linearized matrices to: $filename")
         file = MAT.matopen(filename,"w")
         MAT.write(file,"Kg_all",Kg)

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -446,6 +446,11 @@ Struct with mesh definition
 * `none`:
 
 """
+_int_vector(values) = Int.(collect(values))
+_float_vector(values) = Float64.(collect(values))
+_int_matrix(values) = Int.(values)
+_float_matrix(values) = Float64.(values)
+
 mutable struct Mesh
     nodeNum::Vector{Int}
     numEl::Int
@@ -464,6 +469,28 @@ mutable struct Mesh
     hubNodeNum::Int
     hubPos::Vector{Float64}
     hubAngle::Vector{Float64}
+
+    function Mesh(nodeNum,numEl,numNodes,x,y,z,elNum,conn,type,meshSeg,structuralSpanLocNorm,structuralNodeNumbers,structuralElNumbers,nonRotating,hubNodeNum,hubPos,hubAngle)
+        new(
+            _int_vector(nodeNum),
+            Int(numEl),
+            Int(numNodes),
+            _float_vector(x),
+            _float_vector(y),
+            _float_vector(z),
+            _int_vector(elNum),
+            _int_matrix(conn),
+            _int_vector(type),
+            _int_vector(meshSeg),
+            _float_matrix(structuralSpanLocNorm),
+            _int_matrix(structuralNodeNumbers),
+            _int_matrix(structuralElNumbers),
+            Int(nonRotating),
+            Int(hubNodeNum),
+            _float_vector(hubPos),
+            _float_vector(hubAngle),
+        )
+    end
 end
 
 Mesh(nodeNum,numEl,numNodes,x,y,z,elNum,conn,type,meshSeg,structuralSpanLocNorm,structuralNodeNumbers,structuralElNumbers) = Mesh(nodeNum,numEl,numNodes,x,y,z,elNum,conn,type,meshSeg,structuralSpanLocNorm,structuralNodeNumbers,structuralElNumbers,0,1,zeros(3),zeros(3))
@@ -492,6 +519,17 @@ mutable struct Ort
     Length::Vector{Float64}
     elNum::Matrix{Float64}
     Offset::Matrix{Float64}
+
+    function Ort(Psi_d,Theta_d,Twist_d,Length,elNum,Offset)
+        new(
+            _float_vector(Psi_d),
+            _float_vector(Theta_d),
+            _float_vector(Twist_d),
+            _float_vector(Length),
+            _float_matrix(elNum),
+            _float_matrix(Offset),
+        )
+    end
 end
 
 """
@@ -539,6 +577,8 @@ Struct with element sectional properties, each component is a 1x2 array with dis
 * `aeroCenterOffset::Array{<:float}`: doesn't appear to be used
 * `xaf::Array{<:float}`: x airfoil coordinates (to scale)
 * `yaf::Array{<:float}`: y airfoil coordinates (to scale)
+* `GAy::Union{Nothing,Array{<:float}}`: local-y transverse shear stiffness. When `nothing`, it is computed from `EA`, Poisson's ratio 0.3, and a 5/6 shear correction.
+* `GAz::Union{Nothing,Array{<:float}}`: local-z transverse shear stiffness. When `nothing`, it is computed from `EA`, Poisson's ratio 0.3, and a 5/6 shear correction.
 
 # Outputs:
 * `none`:
@@ -573,9 +613,12 @@ mutable struct SectionPropsArray
     yaf
     added_M22
     added_M33
+    GAy
+    GAz
 end
-SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset) = SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,nothing,nothing,zero(rhoA),zero(rhoA)) #convenience function
-SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,xaf,yaf) = SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,xaf,yaf,zero(rhoA),zero(rhoA)) #convenience function
+SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset) = SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,nothing,nothing,zero(rhoA),zero(rhoA),nothing,nothing) #convenience function
+SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,xaf,yaf) = SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,xaf,yaf,zero(rhoA),zero(rhoA),nothing,nothing) #convenience function
+SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,xaf,yaf,added_M22,added_M33) = SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,xaf,yaf,added_M22,added_M33,nothing,nothing) #convenience function
 
 """
 Internal, see ?Ort and ?SectionPropsArray

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -579,6 +579,8 @@ Struct with element sectional properties, each component is a 1x2 array with dis
 * `yaf::Array{<:float}`: y airfoil coordinates (to scale)
 * `GAy::Union{Nothing,Array{<:float}}`: local-y transverse shear stiffness. When `nothing`, it is computed from `EA`, Poisson's ratio 0.3, and a 5/6 shear correction.
 * `GAz::Union{Nothing,Array{<:float}}`: local-z transverse shear stiffness. When `nothing`, it is computed from `EA`, Poisson's ratio 0.3, and a 5/6 shear correction.
+* `poisson_ratio::Union{Nothing,Array{<:float}}`: Poisson's ratio used for default `GAy`/`GAz` when explicit shear stiffness is omitted.
+* `shear_correction::Union{Nothing,Array{<:float}}`: Timoshenko shear-correction factor used for default `GAy`/`GAz` when explicit shear stiffness is omitted.
 
 # Outputs:
 * `none`:
@@ -615,10 +617,13 @@ mutable struct SectionPropsArray
     added_M33
     GAy
     GAz
+    poisson_ratio
+    shear_correction
 end
-SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset) = SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,nothing,nothing,zero(rhoA),zero(rhoA),nothing,nothing) #convenience function
-SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,xaf,yaf) = SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,xaf,yaf,zero(rhoA),zero(rhoA),nothing,nothing) #convenience function
-SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,xaf,yaf,added_M22,added_M33) = SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,xaf,yaf,added_M22,added_M33,nothing,nothing) #convenience function
+SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset) = SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,nothing,nothing,zero(rhoA),zero(rhoA),nothing,nothing,nothing,nothing) #convenience function
+SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,xaf,yaf) = SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,xaf,yaf,zero(rhoA),zero(rhoA),nothing,nothing,nothing,nothing) #convenience function
+SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,xaf,yaf,added_M22,added_M33) = SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,xaf,yaf,added_M22,added_M33,nothing,nothing,nothing,nothing) #convenience function
+SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,xaf,yaf,added_M22,added_M33,GAy,GAz) = SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,xaf,yaf,added_M22,added_M33,GAy,GAz,nothing,nothing) #convenience function
 
 """
 Internal, see ?Ort and ?SectionPropsArray

--- a/src/timoshenko.jl
+++ b/src/timoshenko.jl
@@ -13,19 +13,34 @@ function defaultTransverseShearStiffness(EA; poisson_ratio=DEFAULT_TIMOSHENKO_PO
     return shear_correction * EA / (2 * (1 + poisson_ratio))
 end
 
+function optionalInterpolatedProperty(sectionProps, field::Symbol, N, default)
+    hasproperty(sectionProps, field) || return default
+    value = getproperty(sectionProps, field)
+    return isnothing(value) ? default : interpolateVal(value, N)
+end
+
 """
     transverseShearStiffness(sectionProps, N) -> GAy, GAz
 
 Return local-y and local-z transverse shear stiffnesses at a quadrature point.
 Explicit `sectionProps.GAy` and `sectionProps.GAz` values take precedence;
 otherwise both directions use the documented isotropic default computed from
-`EA`, Poisson's ratio 0.3, and a 5/6 shear correction.
+`EA`, `sectionProps.poisson_ratio` or Poisson's ratio 0.3, and
+`sectionProps.shear_correction` or a 5/6 shear correction.
 """
 function transverseShearStiffness(sectionProps, N)
     EA = interpolateVal(sectionProps.EA,N)
-    default_GA = defaultTransverseShearStiffness(EA)
-    GAy = isnothing(sectionProps.GAy) ? default_GA : interpolateVal(sectionProps.GAy,N)
-    GAz = isnothing(sectionProps.GAz) ? default_GA : interpolateVal(sectionProps.GAz,N)
+    GAy_data = sectionProps.GAy
+    GAz_data = sectionProps.GAz
+    if isnothing(GAy_data) || isnothing(GAz_data)
+        poisson_ratio = optionalInterpolatedProperty(sectionProps, :poisson_ratio, N, DEFAULT_TIMOSHENKO_POISSON_RATIO)
+        shear_correction = optionalInterpolatedProperty(sectionProps, :shear_correction, N, DEFAULT_TIMOSHENKO_SHEAR_CORRECTION)
+        default_GA = defaultTransverseShearStiffness(EA; poisson_ratio, shear_correction)
+    else
+        default_GA = nothing
+    end
+    GAy = isnothing(GAy_data) ? default_GA : interpolateVal(GAy_data,N)
+    GAz = isnothing(GAz_data) ? default_GA : interpolateVal(GAz_data,N)
     return GAy, GAz
 end
 

--- a/src/timoshenko.jl
+++ b/src/timoshenko.jl
@@ -1364,6 +1364,10 @@ Performs selective nonlinear element calculations. Only stiffness matrix contrib
 *  `eloutput`:    object containing element data
 """
 function calculateTimoshenkoElementNLSS(input)
+    input.analysisType == "M" ||
+        throw(ArgumentError("calculateTimoshenkoElementNLSS currently supports analysisType = \"M\" only"))
+    input.iterationType == "NR" &&
+        throw(ArgumentError("calculateTimoshenkoElementNLSS does not support Newton-Raphson iteration"))
 
     ###-------- assign input block ----------------
     elementOrder   = input.elementOrder
@@ -1380,9 +1384,7 @@ function calculateTimoshenkoElementNLSS(input)
     iterationType  = input.iterationType
 
     ###--------------------------------------------
-    if input.analysisType == "M" #TODO: why are we doing this if the analysis type is hard coded above to be M and required below?
-        disp_iter=disp
-    end
+    disp_iter = disp
 
     numGP = 1 #used reduced integration for nonlinear terms
 
@@ -1475,9 +1477,6 @@ function calculateTimoshenkoElementNLSS(input)
     lambdaTran = SparseArrays.sparse(lambdaTran)
     Ke = lambdaTran*Ke*lambda
 
-    if iterationType == "NR"
-        error("calcTimoElNLSS needs some mods to be used with newton raphson")
-    end
     #----- assign output block ----------------
     Ke = collect(Ke)
 

--- a/src/timoshenko.jl
+++ b/src/timoshenko.jl
@@ -1,3 +1,34 @@
+const DEFAULT_TIMOSHENKO_POISSON_RATIO = 0.3
+const DEFAULT_TIMOSHENKO_SHEAR_CORRECTION = 5 / 6
+
+"""
+    defaultTransverseShearStiffness(EA; poisson_ratio=0.3, shear_correction=5/6)
+
+Compute the default Timoshenko transverse shear stiffness from axial stiffness,
+`GA = shear_correction * EA / (2 * (1 + poisson_ratio))`.
+"""
+function defaultTransverseShearStiffness(EA; poisson_ratio=DEFAULT_TIMOSHENKO_POISSON_RATIO, shear_correction=DEFAULT_TIMOSHENKO_SHEAR_CORRECTION)
+    poisson_ratio > -1 || throw(ArgumentError("poisson_ratio must be greater than -1"))
+    shear_correction > 0 || throw(ArgumentError("shear_correction must be positive"))
+    return shear_correction * EA / (2 * (1 + poisson_ratio))
+end
+
+"""
+    transverseShearStiffness(sectionProps, N) -> GAy, GAz
+
+Return local-y and local-z transverse shear stiffnesses at a quadrature point.
+Explicit `sectionProps.GAy` and `sectionProps.GAz` values take precedence;
+otherwise both directions use the documented isotropic default computed from
+`EA`, Poisson's ratio 0.3, and a 5/6 shear correction.
+"""
+function transverseShearStiffness(sectionProps, N)
+    EA = interpolateVal(sectionProps.EA,N)
+    default_GA = defaultTransverseShearStiffness(EA)
+    GAy = isnothing(sectionProps.GAy) ? default_GA : interpolateVal(sectionProps.GAy,N)
+    GAz = isnothing(sectionProps.GAz) ? default_GA : interpolateVal(sectionProps.GAz,N)
+    return GAy, GAz
+end
+
 """
     calculateTimoshenkoElementInitialRun(elementOrder,modalFlag,xloc,sectionProps,sweepAngle,coneAngle,rollAngle,aeroSweepAngle,x,y,z,concMassFlag,concMass,Omega)
 
@@ -322,17 +353,16 @@ function calculateTimoshenkoElementInitialRun(elementOrder,modalFlag,xloc,sectio
         integrationFactor = Jac * weight[i]
 
         #..... interpolate for value at quad point .....
-        EA   = interpolateVal(sectionProps.EA,N) #struct stiffness terms
-        GA = EA/2.6*5/6
+        GAy, GAz = transverseShearStiffness(sectionProps,N)
         #.... end interpolate value at quad points ........
 
         #Calculate strutural stiffness sub matrices
-        calculateElement1!(GA,integrationFactor,p_N2_x,p_N2_x,K22)
-        calculateElement1!(-GA,integrationFactor,p_N2_x,N6,K26)
-        calculateElement1!(GA,integrationFactor,p_N3_x,p_N3_x,K33)
-        calculateElement1!(GA,integrationFactor,p_N3_x,N5,K35)
-        calculateElement1!(GA,integrationFactor,N5,N5,K55)
-        calculateElement1!(GA,integrationFactor,N6,N6,K66)
+        calculateElement1!(GAy,integrationFactor,p_N2_x,p_N2_x,K22)
+        calculateElement1!(-GAy,integrationFactor,p_N2_x,N6,K26)
+        calculateElement1!(GAz,integrationFactor,p_N3_x,p_N3_x,K33)
+        calculateElement1!(GAz,integrationFactor,p_N3_x,N5,K35)
+        calculateElement1!(GAz,integrationFactor,N5,N5,K55)
+        calculateElement1!(GAy,integrationFactor,N6,N6,K66)
 
     end
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -277,7 +277,7 @@ function createTda(jointType,slaveNodeNum,masterNodeNum,psi,theta,joint)
         ly = joint[6]
         lz = joint[7]
 
-        Rda5 = -1.0*LinearAlgebra.I(6)
+        Rda5 = Matrix(-1.0*LinearAlgebra.I(6))
         Rda5[1:3,4:6] = [0 -lz ly;lz 0 -lx;-ly lx 0]
 
         Tda,dDOF,aDOF = getNodeMaps(Rdd5,Rda5,masterNodeNum,slaveNodeNum,slaveDof5,activeDof5,slaveActiveDof5);

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -507,17 +507,16 @@ Internal, searches over all DOFs in a structural model and determines and return
 function calculateReducedDOFVector(numNodes,numDofPerNode,isConstrained)
 
     #loop over all DOFs in the model checking if constrained by BC or not
-    index = 1
+    numUnconstrained = 0
     for i=1:numNodes
         for j=1:numDofPerNode
             if (isConstrained[(i-1)*numDofPerNode + j]) == 0
-                #             dofVector(index) = (i-1)*numDofPerNode + j #DOF vector only contains unconstrained DOFs
-                index = index + 1
+                numUnconstrained = numUnconstrained + 1
             end
         end
     end
 
-    dofVector = zeros(Int,index)
+    dofVector = zeros(Int,numUnconstrained)
     index = 1
     for i=1:numNodes
         for j=1:numDofPerNode

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -697,7 +697,10 @@ Internal, general routine to calculate an element matrix
 function calculateElement1!(EA,integrationFactor,N1,N2,K)
     len1 = length(N1)
     len2 = length(N2)
-    for i=1:len1
+    size(K, 1) >= len1 && size(K, 2) >= len2 ||
+        throw(DimensionMismatch("element matrix must be at least $(len1)x$(len2), got $(size(K, 1))x$(size(K, 2))"))
+
+    @inbounds for i=1:len1
         for j=1:len2
             K[i,j] = K[i,j] + EA*N1[i]*N2[j]*integrationFactor
         end
@@ -709,7 +712,10 @@ Internal, general routine to calculate an element vector
 """
 function calculateVec1!(f,integrationFactor,N,F)
     len=length(N)
-    for i=1:len
+    length(F) >= len ||
+        throw(DimensionMismatch("element vector must have at least $len entries, got $(length(F))"))
+
+    @inbounds for i=1:len
         F[i] = F[i] + f*N[i]*integrationFactor
     end
 end
@@ -1067,19 +1073,33 @@ global system of equations
 
 """
 function assembly!(Ke,Fe,conn,numNodesPerEl,numDOFPerNode,Kg,Fg)
+    numDOFPerEl = numNodesPerEl*numDOFPerNode
+    length(conn) >= numNodesPerEl ||
+        throw(DimensionMismatch("connectivity must have at least $numNodesPerEl entries, got $(length(conn))"))
+    size(Ke, 1) >= numDOFPerEl && size(Ke, 2) >= numDOFPerEl ||
+        throw(DimensionMismatch("element matrix must be at least $(numDOFPerEl)x$(numDOFPerEl), got $(size(Ke, 1))x$(size(Ke, 2))"))
+    length(Fe) >= numDOFPerEl ||
+        throw(DimensionMismatch("element force vector must have at least $numDOFPerEl entries, got $(length(Fe))"))
 
     count = 1
-    dofList = zeros(Int,numNodesPerEl*numDOFPerNode)
-    for i=1:numNodesPerEl
+    dofList = zeros(Int,numDOFPerEl)
+    @inbounds for i=1:numNodesPerEl
         for j=1:numDOFPerNode
             dofList[count] = (conn[i]-1)*numDOFPerNode + j
             count = count + 1
         end
     end
 
-    numDOFPerEl = length(dofList)
+    minDof = minimum(dofList)
+    maxDof = maximum(dofList)
+    minDof >= 1 || throw(DimensionMismatch("connectivity maps to non-positive global DOF $minDof"))
+    maxDof <= length(Fg) ||
+        throw(DimensionMismatch("force vector has $(length(Fg)) entries but connectivity maps to global DOF $maxDof"))
+    size(Kg, 1) >= maxDof && size(Kg, 2) >= maxDof ||
+        throw(DimensionMismatch("global matrix must include DOF $maxDof, got $(size(Kg, 1))x$(size(Kg, 2))"))
+
     #Assemble element i into global system
-    for j=1:numDOFPerEl
+    @inbounds for j=1:numDOFPerEl
         J = dofList[j]
         Fg[J] = Fg[J] + Fe[j]
         for m=1:numDOFPerEl
@@ -1090,19 +1110,33 @@ function assembly!(Ke,Fe,conn,numNodesPerEl,numDOFPerNode,Kg,Fg)
 end
 
 function assembly(Ke,Fe,conn,numNodesPerEl,numDOFPerNode,Kg,Fg)
+    numDOFPerEl = numNodesPerEl*numDOFPerNode
+    length(conn) >= numNodesPerEl ||
+        throw(DimensionMismatch("connectivity must have at least $numNodesPerEl entries, got $(length(conn))"))
+    size(Ke, 1) >= numDOFPerEl && size(Ke, 2) >= numDOFPerEl ||
+        throw(DimensionMismatch("element matrix must be at least $(numDOFPerEl)x$(numDOFPerEl), got $(size(Ke, 1))x$(size(Ke, 2))"))
+    length(Fe) >= numDOFPerEl ||
+        throw(DimensionMismatch("element force vector must have at least $numDOFPerEl entries, got $(length(Fe))"))
 
     count = 1
-    dofList = zeros(Int,numNodesPerEl*numDOFPerNode)
-    for i=1:numNodesPerEl
+    dofList = zeros(Int,numDOFPerEl)
+    @inbounds for i=1:numNodesPerEl
         for j=1:numDOFPerNode
             dofList[count] = (conn[i]-1)*numDOFPerNode + j
             count = count + 1
         end
     end
 
-    numDOFPerEl = length(dofList)
+    minDof = minimum(dofList)
+    maxDof = maximum(dofList)
+    minDof >= 1 || throw(DimensionMismatch("connectivity maps to non-positive global DOF $minDof"))
+    maxDof <= length(Fg) ||
+        throw(DimensionMismatch("force vector has $(length(Fg)) entries but connectivity maps to global DOF $maxDof"))
+    size(Kg, 1) >= maxDof && size(Kg, 2) >= maxDof ||
+        throw(DimensionMismatch("global matrix must include DOF $maxDof, got $(size(Kg, 1))x$(size(Kg, 2))"))
+
     #Assemble element i into global system
-    for j=1:numDOFPerEl
+    @inbounds for j=1:numDOFPerEl
         J = dofList[j]
         Fg[J] = Fg[J] + Fe[j]
         for m=1:numDOFPerEl

--- a/test/CantileverBeamModal.jl
+++ b/test/CantileverBeamModal.jl
@@ -1,5 +1,6 @@
 using GXBeam, LinearAlgebra
 import OWENSFEA
+import MAT
 # include("../src/OWENSFEA.jl")
 include("./testdeps.jl")
 import Statistics
@@ -189,7 +190,14 @@ platformTurbineConnectionNodeNumber = 1,
 pBC = pBC,
 numNodes = mesh.numNodes)
 
-freq,damp,imagCompSign,U_x_0,U_y_0,U_z_0,theta_x_0,theta_y_0,theta_z_0,U_x_90,U_y_90,U_z_90,theta_x_90,theta_y_90,theta_z_90=OWENSFEA.modal(feamodel,mesh,el;returnDynMatrices=true)
+dyn_matrix_filename = tempname() * ".mat"
+freq,damp,imagCompSign,U_x_0,U_y_0,U_z_0,theta_x_0,theta_y_0,theta_z_0,U_x_90,U_y_90,U_z_90,theta_x_90,theta_y_90,theta_z_90=OWENSFEA.modal(
+    feamodel,
+    mesh,
+    el;
+    returnDynMatrices = true,
+    dynMatrixFilename = dyn_matrix_filename,
+)
 
 # OWENS Frequencies that correspond to the GX beam are every other, and then 1,3,5 of the every other sets corresponds to the analytical
 
@@ -213,3 +221,10 @@ for ifreq = 1:3
     # println(freqOWENS2D[ifreq])
     # println("error = $((freqOWENS2D[ifreq]-freqAnalytical[ifreq])/freqAnalytical[ifreq]*100)")
 end
+
+@test isfile(dyn_matrix_filename)
+dyn_matrices = MAT.matread(dyn_matrix_filename)
+@test dyn_matrices["Kg_all"] isa Matrix{Float64}
+@test size(dyn_matrices["Kg_all"]) == (mesh.numNodes * 6, mesh.numNodes * 6)
+@test size(dyn_matrices["KgTotalM"], 1) < size(dyn_matrices["Kg_all"], 1)
+rm(dyn_matrix_filename; force = true)

--- a/test/CantileverBeamRotatingModal.jl
+++ b/test/CantileverBeamRotatingModal.jl
@@ -76,7 +76,9 @@ for ii = 1:length(mesh.z)-1
     local b = [0.0, 0.0]
     a0 = [0.0, 0.0]
     aeroCenterOffset = [0.0, 0.0]
-    sectionPropsArray[ii] = OWENSFEA.SectionPropsArray(ac,twist_d,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset)
+    GAy = [G*A, G*A]
+    GAz = [G*A, G*A]
+    sectionPropsArray[ii] = OWENSFEA.SectionPropsArray(ac,twist_d,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,nothing,nothing,zero(rhoA),zero(rhoA),GAy,GAz)
 end
 
 rotationalEffects = ones(mesh.numEl)
@@ -128,8 +130,9 @@ xm = vcat(xm_b1, xm_b2)
 # xm = [[xm1[i][3],xm1[i][2],xm1[i][1]] for i = 1:length(xm1)]
 Cab = vcat(Cab_b1, Cab_b2)
 
-# compliance matrix for each beam element
-compliance = fill(Diagonal([1/(E*A), 1/(E*A/2.6*5/6), 1/(E*A/2.6*5/6), 1/(G*J), 1/(E*Iyy), 1/(E*Izz)]), nelem)
+# compliance matrix for each beam element. Use the same explicit transverse
+# shear stiffness as the OWENS section properties above.
+compliance = fill(Diagonal([1/(E*A), 1/(G*A), 1/(G*A), 1/(G*J), 1/(E*Iyy), 1/(E*Izz)]), nelem)
 mass = fill(Diagonal([rho*A, rho*A, rho*A, rho*J, rho*Iyy, rho*Izz]), nelem)
 
 # create assembly of interconnected nonlinear beams

--- a/test/HelperFunctions.jl
+++ b/test/HelperFunctions.jl
@@ -138,6 +138,108 @@ end
     @test GAz == 450.0
 end
 
+@testset "Nonlinear selective stiffness guardrails" begin
+    zeros2 = [0.0, 0.0]
+    section_props = OWENSFEA.SectionPropsArray(
+        zeros2,
+        zeros2,
+        fill(1.0, 2),
+        fill(2.0, 2),
+        fill(3.0, 2),
+        fill(4.0, 2),
+        fill(100.0, 2),
+        fill(0.1, 2),
+        fill(0.2, 2),
+        fill(0.3, 2),
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+    )
+
+    base_input = (
+        elementOrder = 1,
+        x = [0.0, 2.0],
+        xloc = [0.0, 2.0],
+        disp = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.02, 0.10, -0.04, 0.0, 0.0, 0.0],
+        sectionProps = section_props,
+        sweepAngle = 15.0,
+        coneAngle = -5.0,
+        rollAngle = 20.0,
+        useDisp = true,
+        preStress = false,
+        iterationType = "DI",
+        analysisType = "M",
+    )
+    stiffness = OWENSFEA.calculateTimoshenkoElementNLSS(base_input)
+
+    expected_entries = Dict(
+        (1, 1) => -0.7182552312882436,
+        (2, 1) => 2.072437741694245,
+        (3, 1) => -1.065664337369036,
+        (7, 1) => 0.7182552312882436,
+        (8, 1) => -2.072437741694245,
+        (9, 1) => 1.065664337369036,
+        (1, 2) => 0.9340835481944969,
+        (2, 2) => 0.9131441192104118,
+        (3, 2) => -0.2082394337349706,
+        (7, 2) => -0.9340835481944969,
+        (8, 2) => -0.9131441192104118,
+        (9, 2) => 0.2082394337349706,
+        (1, 3) => -0.5627503082325922,
+        (2, 3) => 0.02962232494775191,
+        (3, 3) => -0.1306748476499941,
+        (7, 3) => 0.5627503082325922,
+        (8, 3) => -0.02962232494775191,
+        (9, 3) => 0.1306748476499941,
+        (1, 7) => 0.7182552312882436,
+        (2, 7) => -2.072437741694245,
+        (3, 7) => 1.065664337369036,
+        (7, 7) => -0.7182552312882436,
+        (8, 7) => 2.072437741694245,
+        (9, 7) => -1.065664337369036,
+        (1, 8) => -0.9340835481944969,
+        (2, 8) => -0.9131441192104118,
+        (3, 8) => 0.2082394337349706,
+        (7, 8) => 0.9340835481944969,
+        (8, 8) => 0.9131441192104118,
+        (9, 8) => -0.2082394337349706,
+        (1, 9) => 0.5627503082325922,
+        (2, 9) => -0.02962232494775191,
+        (3, 9) => 0.1306748476499941,
+        (7, 9) => -0.5627503082325922,
+        (8, 9) => 0.02962232494775191,
+        (9, 9) => -0.1306748476499941,
+    )
+    @test size(stiffness) == (12, 12)
+    @test count(!iszero, stiffness) == length(expected_entries)
+    for (index, expected) in expected_entries
+        @test stiffness[index...] ≈ expected atol=1e-14
+    end
+    for index in CartesianIndices(stiffness)
+        Tuple(index) in keys(expected_entries) && continue
+        @test stiffness[index] == 0.0
+    end
+
+    nr_input = merge(base_input, (iterationType = "NR",))
+    @test thrown_message(() -> OWENSFEA.calculateTimoshenkoElementNLSS(nr_input)) ==
+          "ArgumentError: calculateTimoshenkoElementNLSS does not support Newton-Raphson iteration"
+
+    transient_input = merge(base_input, (analysisType = "TNB",))
+    @test thrown_message(() -> OWENSFEA.calculateTimoshenkoElementNLSS(transient_input)) ==
+          "ArgumentError: calculateTimoshenkoElementNLSS currently supports analysisType = \"M\" only"
+end
+
 @testset "Element mass center offsets" begin
     rhoA = 10.0
     rhoIyy = 2.0

--- a/test/HelperFunctions.jl
+++ b/test/HelperFunctions.jl
@@ -1,0 +1,77 @@
+using Test
+import OWENSFEA
+
+@testset "Gauss quadrature points" begin
+    xi, weight = OWENSFEA.getGP(1)
+    @test xi == [0.0]
+    @test weight == [2.0]
+
+    xi, weight = OWENSFEA.getGP(2)
+    @test xi == [-sqrt(1 / 3), sqrt(1 / 3)]
+    @test weight == [1.0, 1.0]
+
+    xi, weight = OWENSFEA.getGP(3)
+    @test xi == [-sqrt(3.0 / 5.0), 0.0, sqrt(3.0 / 5.0)]
+    @test weight == [5.0 / 9.0, 8.0 / 9.0, 5.0 / 9.0]
+
+    xi_inner = sqrt((3.0 - 2 * sqrt(6.0 / 5.0)) / 7.0)
+    xi_outer = sqrt((3.0 + 2 * sqrt(6.0 / 5.0)) / 7.0)
+    weight_inner = (18 + sqrt(30)) / 36.0
+    weight_outer = (18 - sqrt(30)) / 36.0
+    xi, weight = OWENSFEA.getGP(4)
+    @test xi == [xi_inner, -xi_inner, xi_outer, -xi_outer]
+    @test weight == [weight_inner, weight_inner, weight_outer, weight_outer]
+end
+
+@testset "Lagrange shape functions" begin
+    N, p_N_x, Jac = OWENSFEA.calculateShapeFunctions(1, 0.25, [2.0, 6.0])
+    @test N == [0.375, 0.625]
+    @test p_N_x == [-0.25, 0.25]
+    @test Jac == 2.0
+    @test sum(N) == 1.0
+    @test sum(p_N_x) == 0.0
+
+    N, p_N_x, Jac = OWENSFEA.calculateShapeFunctions(2, 0.5, [2.0, 5.0, 8.0])
+    @test N == [-0.125, 0.75, 0.375]
+    @test isapprox(p_N_x, [0.0, -1.0 / 3.0, 1.0 / 3.0]; rtol=0.0, atol=eps())
+    @test Jac == 3.0
+    @test sum(N) == 1.0
+    @test sum(p_N_x) == 0.0
+end
+
+@testset "Reduced DOF and boundary-condition maps" begin
+    is_constrained = [0, 1, 0, 0, 1, 0]
+    pBC = [1.0 2.0 10.0;
+           3.0 1.0 -2.0]
+    expected_map = [1.0, -1.0, 2.0, 3.0, -1.0, 4.0]
+
+    @test OWENSFEA.calculateReducedDOFVector(3, 2, is_constrained) == [1, 3, 4, 6]
+    @test OWENSFEA.calculateReducedDOFVector(1, 2, [1, 1]) == Int[]
+    @test OWENSFEA.calculateBCMap(size(pBC, 1), pBC, 2, collect(1:6)) == expected_map
+    @test OWENSFEA.constructReducedDispVectorMap(3, 2, 6, size(pBC, 1), pBC, is_constrained) == expected_map
+end
+
+@testset "Static boundary-condition application" begin
+    K = [10.0 2.0 3.0 4.0;
+         2.0 20.0 5.0 6.0;
+         3.0 5.0 30.0 7.0;
+         4.0 6.0 7.0 40.0]
+    F = [1.0, 2.0, 3.0, 4.0]
+    original_K = copy(K)
+    original_F = copy(F)
+
+    pBC = [1.0 2.0 1.5;
+           2.0 1.0 -2.0]
+    bc_map = [1.0, -1.0, -1.0, 2.0]
+    BC = OWENSFEA.BC_struct(size(pBC, 1), pBC, 0, 0, [0.0, 1.0, 1.0, 0.0], bc_map, bc_map)
+
+    K_bounded, F_bounded = OWENSFEA.applyBC(K, F, BC, 2)
+
+    @test K_bounded == [10.0 0.0 0.0 4.0;
+                        0.0 1.0 0.0 0.0;
+                        0.0 0.0 1.0 0.0;
+                        4.0 0.0 0.0 40.0]
+    @test F_bounded == [4.0, 1.5, -2.0, 9.0]
+    @test K == original_K
+    @test F == original_F
+end

--- a/test/HelperFunctions.jl
+++ b/test/HelperFunctions.jl
@@ -1,5 +1,15 @@
 using Test
+using LinearAlgebra: I
 import OWENSFEA
+
+function thrown_message(f)
+    try
+        f()
+    catch err
+        return sprint(showerror, err)
+    end
+    return "NO_ERROR"
+end
 
 @testset "Gauss quadrature points" begin
     xi, weight = OWENSFEA.getGP(1)
@@ -49,6 +59,117 @@ end
     @test OWENSFEA.calculateReducedDOFVector(1, 2, [1, 1]) == Int[]
     @test OWENSFEA.calculateBCMap(size(pBC, 1), pBC, 2, collect(1:6)) == expected_map
     @test OWENSFEA.constructReducedDispVectorMap(3, 2, 6, size(pBC, 1), pBC, is_constrained) == expected_map
+end
+
+@testset "Joint dependent-active DOF maps" begin
+    joint(joint_type; psi = 0.0, theta = 0.0, lx = 0.25, ly = 0.5, lz = 0.75) =
+        [1.0, 1.0, 2.0, joint_type, lx, ly, lz, theta]
+
+    expected_by_type = Dict(
+        0 => (d = [7, 8, 9, 10, 11, 12], a = [1, 2, 3, 4, 5, 6],
+              T = Matrix{Float64}(I, 6, 6)),
+        1 => (d = [7, 8, 9], a = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 10.0, 11.0, 12.0],
+              T = [1.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0;
+                   0.0 1.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0;
+                   0.0 0.0 1.0 0.0 0.0 0.0 0.0 0.0 0.0]),
+        2 => (d = [7, 8, 9, 10, 12], a = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 11.0],
+              T = [1.0 0.0 0.0 0.0 0.0 0.0 0.0;
+                   0.0 1.0 0.0 0.0 0.0 0.0 0.0;
+                   0.0 0.0 1.0 0.0 0.0 0.0 0.0;
+                   0.0 0.0 0.0 1.0 0.0 0.0 0.0;
+                   0.0 0.0 0.0 0.0 0.0 1.0 0.0]),
+        3 => (d = [7, 8, 9, 11, 12], a = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 10.0],
+              T = [1.0 0.0 0.0 0.0 0.0 0.0 0.0;
+                   0.0 1.0 0.0 0.0 0.0 0.0 0.0;
+                   0.0 0.0 1.0 0.0 0.0 0.0 0.0;
+                   0.0 0.0 0.0 0.0 1.0 0.0 0.0;
+                   0.0 0.0 0.0 0.0 0.0 1.0 0.0]),
+        4 => (d = [7, 8, 9, 10, 11], a = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 12.0],
+              T = [1.0 0.0 0.0 0.0 0.0 0.0 0.0;
+                   0.0 1.0 0.0 0.0 0.0 0.0 0.0;
+                   0.0 0.0 1.0 0.0 0.0 0.0 0.0;
+                   0.0 0.0 0.0 1.0 0.0 0.0 0.0;
+                   0.0 0.0 0.0 0.0 1.0 0.0 0.0]),
+        5 => (d = [7, 8, 9, 10, 11, 12], a = [1, 2, 3, 4, 5, 6],
+              T = [1.0 0.0 0.0 0.0 0.75 -0.5;
+                   0.0 1.0 0.0 -0.75 0.0 0.25;
+                   0.0 0.0 1.0 0.5 -0.25 0.0;
+                   0.0 0.0 0.0 1.0 0.0 0.0;
+                   0.0 0.0 0.0 0.0 1.0 0.0;
+                   0.0 0.0 0.0 0.0 0.0 1.0]),
+    )
+
+    for joint_type in 0:5
+        Tda, dDOF, aDOF = OWENSFEA.createTda(joint_type, 2, 1, 0.0, 0.0, joint(joint_type))
+        expected = expected_by_type[joint_type]
+        @test dDOF == expected.d
+        @test vec(aDOF) == expected.a
+        @test Matrix(Tda) == expected.T
+        @test eltype(Matrix(Tda)) === Float64
+    end
+
+    Tda, dDOF, aDOF = OWENSFEA.createTda(4, 2, 1, 0.0, 90.0, joint(4; theta = 90.0))
+    @test dDOF == [7, 8, 9, 11, 12]
+    @test vec(aDOF) == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 10.0]
+    @test Matrix(Tda) == expected_by_type[3].T
+
+    @test thrown_message(() -> OWENSFEA.createTda(9, 2, 1, 0.0, 0.0, joint(9))) ==
+        "Correct jointType not specified, should be 1, 2, 3, 4, or 5"
+    @test thrown_message(() -> OWENSFEA.getNodeMaps(zeros(2, 2), zeros(2, 3), 1, 2, [1, 2], [1, 2, 3], Int[])) ==
+        "Singular joint transformation matrix. Exiting"
+end
+
+@testset "Joint slave DOF extraction branches" begin
+    jointrow(joint_type; psi = 0.0, theta = 0.0) = [1.0 1.0 2.0 joint_type 0.0 0.0 psi theta]
+    expected_slave_dofs = (
+        (jointrow(1), [7, 8, 9]),
+        (jointrow(2; psi = 90.0), [7, 8, 9, 11, 12]),
+        (jointrow(2; psi = 0.0), [7, 8, 9, 10, 12]),
+        (jointrow(3; theta = 90.0), [7, 8, 9, 10, 11]),
+        (jointrow(3; psi = 90.0), [7, 8, 9, 10, 12]),
+        (jointrow(3), [7, 8, 9, 11, 12]),
+        (jointrow(4; theta = 90.0, psi = 90.0), [7, 8, 9, 10, 12]),
+        (jointrow(4; theta = 90.0), [7, 8, 9, 11, 12]),
+        (jointrow(4), [7, 8, 9, 10, 11]),
+        (jointrow(5), [7, 8, 9, 10, 11, 12]),
+    )
+
+    for (joint_data, slave_dofs) in expected_slave_dofs
+        adNumDof, aNumDof, actual_slave_dofs = OWENSFEA.extractdaInfo(joint_data, 2, 6)
+        @test adNumDof == 12
+        @test aNumDof == 12 - length(slave_dofs)
+        @test actual_slave_dofs == slave_dofs
+    end
+end
+
+@testset "Concentrated nodal term parsing" begin
+    full_terms = Any[
+        1 "M6" 2 3 4.5;
+        1 "K6" 3 4 5.5;
+        2 "C6" 4 5 6.5;
+        2 "F" 6 1 7.5
+    ]
+    nodal = @test_logs (:warn, "Concentrated loads are one-dimensional, second degree of freedom input is ignored.") OWENSFEA.applyConcentratedTerms(2, 6; data = full_terms)
+    @test nodal.concMass[2, 3] == 4.5
+    @test nodal.concStiff[3, 4] == 5.5
+    @test nodal.concDamp[10, 11] == 6.5
+    @test nodal.concLoad[12] == 7.5
+    @test size(nodal.concMass) == (12, 12)
+    @test eltype(nodal.concLoad) === Float64
+
+    diagonal_terms = Any[
+        1 "M" 2 1.5;
+        1 "K" 3 2.5;
+        1 "C" 4 3.5;
+        1 "F" 5 4.5
+    ]
+    diagonal = @test_logs (:warn, "Only one degree of freedom given for concentrated mass; applying at diagonal.") (:warn, "Only one degree of freedom given for concentrated stiffness; applying at diagonal.") (:warn, "Only one degree of freedom given for concentrated damping; applying at diagonal.") OWENSFEA.applyConcentratedTerms(1, 6; data = diagonal_terms)
+    @test diagonal.concMass[2, 2] == 1.5
+    @test diagonal.concStiff[3, 3] == 2.5
+    @test diagonal.concDamp[4, 4] == 3.5
+    @test diagonal.concLoad[5] == 4.5
+    @test thrown_message(() -> OWENSFEA.applyConcentratedTerms(1, 6; data = Any[1 "X" 1 1.0])) ==
+        "Unknown Nodal Data Type"
 end
 
 @testset "Static boundary-condition application" begin

--- a/test/HelperFunctions.jl
+++ b/test/HelperFunctions.jl
@@ -49,6 +49,39 @@ end
     @test sum(p_N_x) == 0.0
 end
 
+@testset "Element accumulation and assembly kernels" begin
+    K = zeros(2, 3)
+    OWENSFEA.calculateElement1!(2.0, 0.25, [1.0, 2.0], [3.0, 5.0, 7.0], K)
+    @test K == [1.5 2.5 3.5; 3.0 5.0 7.0]
+
+    F = zeros(2)
+    OWENSFEA.calculateVec1!(4.0, 0.5, [2.0, 3.0], F)
+    @test F == [4.0, 6.0]
+
+    Ke = reshape(collect(1.0:16.0), 4, 4)
+    Fe = [10.0, 20.0, 30.0, 40.0]
+    conn = [2, 4]
+    dofs = [3, 4, 7, 8]
+
+    Kg = zeros(8, 8)
+    Fg = zeros(8)
+    OWENSFEA.assembly!(Ke, Fe, conn, 2, 2, Kg, Fg)
+    @test Fg[dofs] == Fe
+    @test Kg[dofs, dofs] == Ke
+    @test sum(Fg) == 100.0
+    @test sum(Kg) == 136.0
+
+    Kg_returned, Fg_returned = OWENSFEA.assembly(Ke, Fe, conn, 2, 2, zeros(8, 8), zeros(8))
+    @test Fg_returned == Fg
+    @test Kg_returned == Kg
+
+    @test_throws DimensionMismatch OWENSFEA.calculateElement1!(2.0, 0.25, [1.0, 2.0], [3.0, 5.0], zeros(1, 2))
+    @test_throws DimensionMismatch OWENSFEA.calculateVec1!(4.0, 0.5, [2.0, 3.0], zeros(1))
+    @test_throws DimensionMismatch OWENSFEA.assembly!(zeros(3, 4), Fe, conn, 2, 2, zeros(8, 8), zeros(8))
+    @test_throws DimensionMismatch OWENSFEA.assembly!(Ke, Fe, [0, 4], 2, 2, zeros(8, 8), zeros(8))
+    @test_throws DimensionMismatch OWENSFEA.assembly!(Ke, Fe, conn, 2, 2, zeros(7, 7), zeros(7))
+end
+
 @testset "Mesh and orientation constructors normalize input types" begin
     mesh = OWENSFEA.Mesh(
         1:2,

--- a/test/HelperFunctions.jl
+++ b/test/HelperFunctions.jl
@@ -49,6 +49,62 @@ end
     @test sum(p_N_x) == 0.0
 end
 
+@testset "Mesh and orientation constructors normalize input types" begin
+    mesh = OWENSFEA.Mesh(
+        1:2,
+        1.0,
+        2.0,
+        0:1,
+        [0, 0],
+        [0, 0],
+        1:1,
+        [1.0 2.0],
+        [0.0],
+        [2.0],
+        [0 1],
+        [1.0 2.0],
+        [1.0 1.0],
+    )
+
+    @test mesh.nodeNum == [1, 2]
+    @test mesh.nodeNum isa Vector{Int}
+    @test mesh.numEl == 1
+    @test mesh.numNodes == 2
+    @test mesh.x == [0.0, 1.0]
+    @test mesh.x isa Vector{Float64}
+    @test mesh.conn == [1 2]
+    @test mesh.conn isa Matrix{Int}
+    @test mesh.structuralSpanLocNorm == [0.0 1.0]
+    @test mesh.structuralNodeNumbers == [1 2]
+    @test mesh.structuralElNumbers == [1 1]
+
+    ort = OWENSFEA.Ort((0, 10), 0:1, [0, 0], [1, 1], [1 2], [1 2 3; 4 5 6])
+    @test ort.Psi_d == [0.0, 10.0]
+    @test ort.Psi_d isa Vector{Float64}
+    @test ort.Theta_d == [0.0, 1.0]
+    @test ort.elNum == [1.0 2.0]
+    @test ort.Offset == [1.0 2.0 3.0; 4.0 5.0 6.0]
+end
+
+@testset "Timoshenko transverse shear stiffness" begin
+    @test OWENSFEA.defaultTransverseShearStiffness(260.0) ≈ 260.0 / 2.6 * 5 / 6 atol=1e-12
+    @test OWENSFEA.defaultTransverseShearStiffness(300.0; poisson_ratio=0.25, shear_correction=0.8) == 96.0
+    @test_throws ArgumentError OWENSFEA.defaultTransverseShearStiffness(1.0; poisson_ratio=-1.0)
+    @test_throws ArgumentError OWENSFEA.defaultTransverseShearStiffness(1.0; shear_correction=0.0)
+
+    N = [0.25, 0.75]
+    default_props = (EA = [260.0, 520.0], GAy = nothing, GAz = nothing)
+    GAy, GAz = OWENSFEA.transverseShearStiffness(default_props, N)
+    expected_default = OWENSFEA.defaultTransverseShearStiffness(455.0)
+    @test GAy == expected_default
+    @test GAz == expected_default
+
+    explicit_props = (EA = [260.0, 520.0], GAy = [100.0, 200.0], GAz = [300.0, 500.0])
+    GAy, GAz = OWENSFEA.transverseShearStiffness(explicit_props, N)
+    @test GAy == 175.0
+    @test GAz == 450.0
+end
+
 @testset "Element mass center offsets" begin
     rhoA = 10.0
     rhoIyy = 2.0

--- a/test/HelperFunctions.jl
+++ b/test/HelperFunctions.jl
@@ -49,6 +49,60 @@ end
     @test sum(p_N_x) == 0.0
 end
 
+@testset "Element mass center offsets" begin
+    rhoA = 10.0
+    rhoIyy = 2.0
+    rhoIzz = 3.0
+    rhoIyz = 0.4
+    rhoJ = 5.0
+    ycm = 0.2
+    zcm = -0.3
+    x = 1.0
+    y = 0.5
+    z = 0.75
+    integration_factor = 2.0
+
+    M, Itens, xm = OWENSFEA.calculateElementMass(
+        rhoA,
+        rhoIyy,
+        rhoIzz,
+        rhoIyz,
+        rhoJ,
+        ycm,
+        zcm,
+        x,
+        y,
+        z,
+        integration_factor,
+        1.5,
+        zeros(3, 3),
+        zeros(3),
+    )
+
+    offset_y = y + ycm
+    offset_z = z + zcm
+    expected_mass = 21.5
+    expected_inertia =
+        rhoA * integration_factor *
+        [
+            offset_y^2+offset_z^2 -x*offset_y -x*offset_z
+            -x*offset_y x^2+offset_z^2 -offset_y*offset_z
+            -x*offset_z -offset_y*offset_z x^2+offset_y^2
+        ] +
+        integration_factor *
+        [
+            rhoJ 0.0 0.0
+            0.0 rhoIyy rhoIyz
+            0.0 rhoIyz rhoIzz
+        ]
+
+    @test M == expected_mass
+    @test Itens == expected_inertia
+    @test xm == rhoA * integration_factor * [x, offset_y, offset_z]
+    @test xm[2] == 14.0
+    @test xm[3] == 9.0
+end
+
 @testset "Reduced DOF and boundary-condition maps" begin
     is_constrained = [0, 1, 0, 0, 1, 0]
     pBC = [1.0 2.0 10.0;

--- a/test/HelperFunctions.jl
+++ b/test/HelperFunctions.jl
@@ -132,10 +132,83 @@ end
     @test GAy == expected_default
     @test GAz == expected_default
 
+    material_props = (
+        EA = [260.0, 520.0],
+        GAy = nothing,
+        GAz = nothing,
+        poisson_ratio = [0.2, 0.4],
+        shear_correction = [0.7, 0.9],
+    )
+    GAy, GAz = OWENSFEA.transverseShearStiffness(material_props, N)
+    expected_material = OWENSFEA.defaultTransverseShearStiffness(455.0; poisson_ratio = 0.35, shear_correction = 0.85)
+    @test GAy ≈ expected_material atol=5e-14 rtol=0.0
+    @test GAz ≈ expected_material atol=5e-14 rtol=0.0
+
+    zeros2 = [0.0, 0.0]
+    section_props = OWENSFEA.SectionPropsArray(
+        zeros2,
+        zeros2,
+        fill(1.0, 2),
+        fill(2.0, 2),
+        fill(3.0, 2),
+        fill(4.0, 2),
+        [260.0, 520.0],
+        fill(0.1, 2),
+        fill(0.2, 2),
+        fill(0.3, 2),
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        nothing,
+        nothing,
+        zeros2,
+        zeros2,
+        nothing,
+        nothing,
+        [0.2, 0.4],
+        [0.7, 0.9],
+    )
+    @test section_props.poisson_ratio == [0.2, 0.4]
+    @test section_props.shear_correction == [0.7, 0.9]
+    GAy, GAz = OWENSFEA.transverseShearStiffness(section_props, N)
+    @test GAy ≈ expected_material atol=5e-14 rtol=0.0
+    @test GAz ≈ expected_material atol=5e-14 rtol=0.0
+
     explicit_props = (EA = [260.0, 520.0], GAy = [100.0, 200.0], GAz = [300.0, 500.0])
     GAy, GAz = OWENSFEA.transverseShearStiffness(explicit_props, N)
     @test GAy == 175.0
     @test GAz == 450.0
+
+    explicit_overrides_material = (
+        EA = [260.0, 520.0],
+        GAy = [100.0, 200.0],
+        GAz = [300.0, 500.0],
+        poisson_ratio = [-1.0, -1.0],
+        shear_correction = [0.0, 0.0],
+    )
+    GAy, GAz = OWENSFEA.transverseShearStiffness(explicit_overrides_material, N)
+    @test GAy == 175.0
+    @test GAz == 450.0
+
+    @test_throws ArgumentError OWENSFEA.transverseShearStiffness(
+        (EA = [260.0, 520.0], GAy = nothing, GAz = nothing, poisson_ratio = [-1.0, -1.0], shear_correction = [5 / 6, 5 / 6]),
+        N,
+    )
+    @test_throws ArgumentError OWENSFEA.transverseShearStiffness(
+        (EA = [260.0, 520.0], GAy = nothing, GAz = nothing, poisson_ratio = [0.3, 0.3], shear_correction = [0.0, 0.0]),
+        N,
+    )
 end
 
 @testset "Nonlinear selective stiffness guardrails" begin

--- a/test/SpinningBeamDiagnostics.jl
+++ b/test/SpinningBeamDiagnostics.jl
@@ -1,0 +1,138 @@
+using Test
+import OWENSFEA
+
+function _spinning_beam_fixture(; L=2.0, nelem=4)
+    b = 0.05
+    h = 0.02
+    A = b*h
+    E = 2.1e11
+    nu = 0.28
+    G = E/(2*(1 + nu))
+    rho = 7800.0
+    Iyy = b*h^3/12
+    Izz = b^3*h/12
+    J = Iyy + Izz
+
+    rhoA = rho*A
+    zeros2 = [0.0, 0.0]
+    section_props = Array{OWENSFEA.SectionPropsArray, 1}(undef, nelem)
+    for i = 1:nelem
+        section_props[i] = OWENSFEA.SectionPropsArray(
+            zeros2, zeros2,
+            fill(rhoA, 2),
+            fill(E*Iyy, 2),
+            fill(E*Izz, 2),
+            fill(G*J, 2),
+            fill(E*A, 2),
+            fill(rho*Iyy, 2),
+            fill(rho*Izz, 2),
+            fill(rho*J, 2),
+            zeros2, zeros2, zeros2, zeros2,
+            zeros2, zeros2, zeros2, zeros2, zeros2, zeros2,
+            zeros2, zeros2, zeros2, zeros2,
+            nothing, nothing,
+            zeros2, zeros2,
+            fill(G*A, 2),
+            fill(G*A, 2),
+        )
+    end
+
+    x = collect(range(0.0, L, length=nelem + 1))
+    conn = hcat(collect(1:nelem), collect(2:nelem + 1))
+    mesh = OWENSFEA.Mesh(
+        collect(1:nelem + 1),
+        nelem,
+        nelem + 1,
+        x,
+        zeros(nelem + 1),
+        zeros(nelem + 1),
+        collect(1:nelem),
+        conn,
+        zeros(Int, nelem),
+        [nelem],
+        zeros(1, 1),
+        zeros(Int, 1, 1),
+        zeros(Int, 1, 1),
+    )
+    el = OWENSFEA.El(
+        section_props,
+        fill(L/nelem, nelem),
+        zeros(nelem),
+        zeros(nelem),
+        zeros(nelem),
+        ones(nelem),
+    )
+
+    return mesh, el, rhoA, L
+end
+
+function _spinning_beam_model(mesh)
+    root_fixed = [
+        1 1 0
+        1 2 0
+        1 3 0
+        1 4 0
+        1 5 0
+        1 6 0
+    ]
+    return OWENSFEA.FEAModel(;
+        analysisType="S",
+        dataOutputFilename="none",
+        joint=zeros(0, 8),
+        pBC=root_fixed,
+        numNodes=mesh.numNodes,
+        nlOn=false,
+        gravityOn=false,
+        iterationType="LINEAR",
+        maxNumLoadSteps=3,
+    )
+end
+
+function _root_reaction(mesh, el; Omega=0.0, OmegaDot=0.0)
+    feamodel = _spinning_beam_model(mesh)
+    el_storage = OWENSFEA.initialElementCalculations(feamodel, el, mesh)
+    displ0 = zeros(mesh.numNodes*6)
+    _, _, success, reaction = redirect_stdout(devnull) do
+        OWENSFEA.staticAnalysis(
+            feamodel,
+            mesh,
+            el,
+            displ0,
+            Omega,
+            Omega,
+            el_storage;
+            OmegaDot,
+        )
+    end
+    return success, reaction[1:6]
+end
+
+@testset "Straight spinning beam reaction diagnostics" begin
+    mesh, el, rhoA, L = _spinning_beam_fixture()
+
+    spin_hz = 5.0
+    success, reaction = _root_reaction(mesh, el; Omega=spin_hz)
+    omega = 2*pi*spin_hz
+    expected_axial_reaction = -rhoA*omega^2*L^2/2
+
+    @test success
+    @test isapprox(reaction[1], expected_axial_reaction; rtol=1e-3)
+    @test isapprox(reaction[2], 0.0; atol=1e-10*abs(expected_axial_reaction))
+    @test isapprox(reaction[3], 0.0; atol=1e-10*abs(expected_axial_reaction))
+    @test isapprox(reaction[4], 0.0; atol=1e-10*abs(expected_axial_reaction)*L)
+    @test isapprox(reaction[5], 0.0; atol=1e-10*abs(expected_axial_reaction)*L)
+    @test isapprox(reaction[6], 0.0; atol=1e-10*abs(expected_axial_reaction)*L)
+
+    spin_accel_hz = 2.0
+    success, reaction = _root_reaction(mesh, el; OmegaDot=spin_accel_hz)
+    alpha = 2*pi*spin_accel_hz
+    expected_tangential_reaction = rhoA*alpha*L^2/2
+    expected_spin_axis_torque = rhoA*alpha*L^3/3
+
+    @test success
+    @test isapprox(reaction[2], expected_tangential_reaction; rtol=1e-5)
+    @test isapprox(reaction[6], expected_spin_axis_torque; rtol=1e-5)
+    @test isapprox(reaction[3], 0.0; atol=1e-10*abs(expected_tangential_reaction))
+    @test isapprox(reaction[4], 0.0; atol=1e-10*abs(expected_spin_axis_torque))
+    @test isapprox(reaction[5], 0.0; atol=1e-10*abs(expected_spin_axis_torque))
+end

--- a/test/SpinningBeamDiagnostics.jl
+++ b/test/SpinningBeamDiagnostics.jl
@@ -136,3 +136,24 @@ end
     @test isapprox(reaction[4], 0.0; atol=1e-10*abs(expected_spin_axis_torque))
     @test isapprox(reaction[5], 0.0; atol=1e-10*abs(expected_spin_axis_torque))
 end
+
+@testset "Static global spin axis limitation" begin
+    mesh, el, _, _ = _spinning_beam_fixture()
+    feamodel = _spinning_beam_model(mesh)
+    el_storage = OWENSFEA.initialElementCalculations(feamodel, el, mesh)
+    displ0 = zeros(mesh.numNodes*6)
+
+    # staticAnalysis only exposes scalar Omega/OmegaDot, which is added to the
+    # hub z-axis in the Timoshenko element.  A future HAWT/global-x diagnostic
+    # needs a public steady API path for the existing omegaVec/rbData plumbing.
+    @test_throws MethodError OWENSFEA.staticAnalysis(
+        feamodel,
+        mesh,
+        el,
+        displ0,
+        0.0,
+        0.0,
+        el_storage;
+        rbData=[0.0, 0.0, 0.0, 2*pi, 0.0, 0.0, 0.0, 0.0, 0.0],
+    )
+end

--- a/test/SpinningBeamDiagnostics.jl
+++ b/test/SpinningBeamDiagnostics.jl
@@ -1,11 +1,11 @@
 using Test
 import OWENSFEA
 
-function _spinning_beam_fixture(; L=2.0, nelem=4)
+function _spinning_beam_fixture(; L=2.0, nelem=4, y_offset=0.0, stiffness_scale=1.0)
     b = 0.05
     h = 0.02
     A = b*h
-    E = 2.1e11
+    E = 2.1e11*stiffness_scale
     nu = 0.28
     G = E/(2*(1 + nu))
     rho = 7800.0
@@ -44,7 +44,7 @@ function _spinning_beam_fixture(; L=2.0, nelem=4)
         nelem,
         nelem + 1,
         x,
-        zeros(nelem + 1),
+        fill(y_offset, nelem + 1),
         zeros(nelem + 1),
         collect(1:nelem),
         conn,
@@ -105,6 +105,35 @@ function _root_reaction(mesh, el; Omega=0.0, OmegaDot=0.0)
         )
     end
     return success, reaction[1:6]
+end
+
+@testset "Eccentric spinning beam spin-acceleration reactions" begin
+    y_offset = 0.3
+    spin_accel_hz = 2.0
+    mesh, el, rhoA, L = _spinning_beam_fixture(; y_offset, stiffness_scale=1e4)
+    success, reaction = _root_reaction(mesh, el; OmegaDot=spin_accel_hz)
+
+    alpha = 2*pi*spin_accel_hz
+    expected_x_reaction = -rhoA*alpha*y_offset*L
+    expected_y_reaction = rhoA*alpha*L^2/2
+    expected_spanwise_spin_axis_torque = rhoA*alpha*L^3/3
+    expected_offset_spin_axis_torque = rhoA*alpha*y_offset^2*L
+
+    @test success
+    @test isapprox(reaction[1], expected_x_reaction; rtol=1e-5)
+    @test isapprox(reaction[2], expected_y_reaction; rtol=1e-5)
+    # The current root-reaction moment channel omits the eccentric y^2 term even
+    # though the corresponding x-force is present. Pin both sides so a future
+    # #15/#17 torque fix is an intentional test update.
+    @test isapprox(reaction[6], expected_spanwise_spin_axis_torque; rtol=1e-5)
+    @test isapprox(
+        expected_spanwise_spin_axis_torque + expected_offset_spin_axis_torque - reaction[6],
+        expected_offset_spin_axis_torque;
+        rtol=1e-5,
+    )
+    @test isapprox(reaction[3], 0.0; atol=1e-10*abs(expected_y_reaction))
+    @test isapprox(reaction[4], 0.0; atol=1e-10*abs(expected_spanwise_spin_axis_torque))
+    @test isapprox(reaction[5], 0.0; atol=1e-10*abs(expected_spanwise_spin_axis_torque))
 end
 
 @testset "Straight spinning beam reaction diagnostics" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,7 +20,7 @@ end
     include("CantileverBeamRotatingModal.jl")
 end
 
-@testset "Straight spinning beam reaction diagnostics" begin
+@testset "Spinning beam reaction diagnostics" begin
     include("SpinningBeamDiagnostics.jl")
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,9 @@
 using Test
 
+@testset "Helper Functions" begin
+    include("HelperFunctions.jl")
+end
+
 @testset "Cantilever Beam Modal" begin
     include("CantileverBeamModal.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,10 @@ end
     include("CantileverBeamRotatingModal.jl")
 end
 
+@testset "Straight spinning beam reaction diagnostics" begin
+    include("SpinningBeamDiagnostics.jl")
+end
+
 @testset "Cantilever Beam Unsteady Response to Unsteady Tip Load" begin
     include("UnsteadyBeam.jl")
 end


### PR DESCRIPTION
## Summary
- opens the accumulated OWENSFEA triage branch for review
- includes matrix-output hardening, mass-center/regression pins, docs, bounds-check assembly guards, shear-stiffness fixes, constructor normalization, and rotating/spinning reaction diagnostics
- see OWENS.jl/ISSUE_TODO_TRIAGE.md for the running checkpoint log by commit

## Verification
Individual commits in this branch were tested as they were created; this PR-opening step did not rerun the full OWENSFEA suite.

References OWENSFEA #14, #15, #18, #29, #31, #33 and related OWENS issues noted in commit messages.