### PR TITLE
Add section shear material defaults

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -37,7 +37,9 @@ jobs:
           repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
           path: downstream
       - name: Workaround Pkg.jl bug
-        run: sed -i -e 's/^OWENSFEA = {.*}//' downstream/Project.toml
+        run: |
+          sed -i -e 's/^OWENSFEA = {.*}//' downstream/Project.toml
+          sed -i -e '/^\[sources\.OWENSFEA\]$/,+1d' downstream/Project.toml
       - name: Load this and run the downstream tests
         shell: julia --project=downstream {0}
         run: |

--- a/docs/src/model_assembly.md
+++ b/docs/src/model_assembly.md
@@ -25,8 +25,11 @@ center of mass before mapping into FEA inputs.
 
 When `GAy` and `GAz` are omitted, the Timoshenko element computes both
 transverse shear stiffnesses from `EA`, Poisson's ratio 0.3, and a 5/6 shear
-correction. Composite or externally generated section-property workflows should
-pass explicit `GAy` and `GAz` values when available.
+correction unless `poisson_ratio` or `shear_correction` arrays are supplied on
+the section properties. Composite or externally generated section-property
+workflows should pass explicit `GAy` and `GAz` values when available; otherwise
+they should pass the material Poisson ratio and shear-correction factor used to
+derive the transverse shear stiffnesses.
 
 ## Boundary Conditions
 

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -579,6 +579,8 @@ Struct with element sectional properties, each component is a 1x2 array with dis
 * `yaf::Array{<:float}`: y airfoil coordinates (to scale)
 * `GAy::Union{Nothing,Array{<:float}}`: local-y transverse shear stiffness. When `nothing`, it is computed from `EA`, Poisson's ratio 0.3, and a 5/6 shear correction.
 * `GAz::Union{Nothing,Array{<:float}}`: local-z transverse shear stiffness. When `nothing`, it is computed from `EA`, Poisson's ratio 0.3, and a 5/6 shear correction.
+* `poisson_ratio::Union{Nothing,Array{<:float}}`: Poisson's ratio used for default `GAy`/`GAz` when explicit shear stiffness is omitted.
+* `shear_correction::Union{Nothing,Array{<:float}}`: Timoshenko shear-correction factor used for default `GAy`/`GAz` when explicit shear stiffness is omitted.
 
 # Outputs:
 * `none`:
@@ -615,10 +617,13 @@ mutable struct SectionPropsArray
     added_M33
     GAy
     GAz
+    poisson_ratio
+    shear_correction
 end
-SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset) = SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,nothing,nothing,zero(rhoA),zero(rhoA),nothing,nothing) #convenience function
-SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,xaf,yaf) = SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,xaf,yaf,zero(rhoA),zero(rhoA),nothing,nothing) #convenience function
-SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,xaf,yaf,added_M22,added_M33) = SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,xaf,yaf,added_M22,added_M33,nothing,nothing) #convenience function
+SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset) = SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,nothing,nothing,zero(rhoA),zero(rhoA),nothing,nothing,nothing,nothing) #convenience function
+SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,xaf,yaf) = SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,xaf,yaf,zero(rhoA),zero(rhoA),nothing,nothing,nothing,nothing) #convenience function
+SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,xaf,yaf,added_M22,added_M33) = SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,xaf,yaf,added_M22,added_M33,nothing,nothing,nothing,nothing) #convenience function
+SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,xaf,yaf,added_M22,added_M33,GAy,GAz) = SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,xaf,yaf,added_M22,added_M33,GAy,GAz,nothing,nothing) #convenience function
 
 """
 Internal, see ?Ort and ?SectionPropsArray

--- a/src/timoshenko.jl
+++ b/src/timoshenko.jl
@@ -13,19 +13,34 @@ function defaultTransverseShearStiffness(EA; poisson_ratio=DEFAULT_TIMOSHENKO_PO
     return shear_correction * EA / (2 * (1 + poisson_ratio))
 end
 
+function optionalInterpolatedProperty(sectionProps, field::Symbol, N, default)
+    hasproperty(sectionProps, field) || return default
+    value = getproperty(sectionProps, field)
+    return isnothing(value) ? default : interpolateVal(value, N)
+end
+
 """
     transverseShearStiffness(sectionProps, N) -> GAy, GAz
 
 Return local-y and local-z transverse shear stiffnesses at a quadrature point.
 Explicit `sectionProps.GAy` and `sectionProps.GAz` values take precedence;
 otherwise both directions use the documented isotropic default computed from
-`EA`, Poisson's ratio 0.3, and a 5/6 shear correction.
+`EA`, `sectionProps.poisson_ratio` or Poisson's ratio 0.3, and
+`sectionProps.shear_correction` or a 5/6 shear correction.
 """
 function transverseShearStiffness(sectionProps, N)
     EA = interpolateVal(sectionProps.EA,N)
-    default_GA = defaultTransverseShearStiffness(EA)
-    GAy = isnothing(sectionProps.GAy) ? default_GA : interpolateVal(sectionProps.GAy,N)
-    GAz = isnothing(sectionProps.GAz) ? default_GA : interpolateVal(sectionProps.GAz,N)
+    GAy_data = sectionProps.GAy
+    GAz_data = sectionProps.GAz
+    if isnothing(GAy_data) || isnothing(GAz_data)
+        poisson_ratio = optionalInterpolatedProperty(sectionProps, :poisson_ratio, N, DEFAULT_TIMOSHENKO_POISSON_RATIO)
+        shear_correction = optionalInterpolatedProperty(sectionProps, :shear_correction, N, DEFAULT_TIMOSHENKO_SHEAR_CORRECTION)
+        default_GA = defaultTransverseShearStiffness(EA; poisson_ratio, shear_correction)
+    else
+        default_GA = nothing
+    end
+    GAy = isnothing(GAy_data) ? default_GA : interpolateVal(GAy_data,N)
+    GAz = isnothing(GAz_data) ? default_GA : interpolateVal(GAz_data,N)
     return GAy, GAz
 end
 

--- a/test/HelperFunctions.jl
+++ b/test/HelperFunctions.jl
@@ -132,10 +132,83 @@ end
     @test GAy == expected_default
     @test GAz == expected_default
 
+    material_props = (
+        EA = [260.0, 520.0],
+        GAy = nothing,
+        GAz = nothing,
+        poisson_ratio = [0.2, 0.4],
+        shear_correction = [0.7, 0.9],
+    )
+    GAy, GAz = OWENSFEA.transverseShearStiffness(material_props, N)
+    expected_material = OWENSFEA.defaultTransverseShearStiffness(455.0; poisson_ratio = 0.35, shear_correction = 0.85)
+    @test GAy ≈ expected_material atol=5e-14 rtol=0.0
+    @test GAz ≈ expected_material atol=5e-14 rtol=0.0
+
+    zeros2 = [0.0, 0.0]
+    section_props = OWENSFEA.SectionPropsArray(
+        zeros2,
+        zeros2,
+        fill(1.0, 2),
+        fill(2.0, 2),
+        fill(3.0, 2),
+        fill(4.0, 2),
+        [260.0, 520.0],
+        fill(0.1, 2),
+        fill(0.2, 2),
+        fill(0.3, 2),
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        nothing,
+        nothing,
+        zeros2,
+        zeros2,
+        nothing,
+        nothing,
+        [0.2, 0.4],
+        [0.7, 0.9],
+    )
+    @test section_props.poisson_ratio == [0.2, 0.4]
+    @test section_props.shear_correction == [0.7, 0.9]
+    GAy, GAz = OWENSFEA.transverseShearStiffness(section_props, N)
+    @test GAy ≈ expected_material atol=5e-14 rtol=0.0
+    @test GAz ≈ expected_material atol=5e-14 rtol=0.0
+
     explicit_props = (EA = [260.0, 520.0], GAy = [100.0, 200.0], GAz = [300.0, 500.0])
     GAy, GAz = OWENSFEA.transverseShearStiffness(explicit_props, N)
     @test GAy == 175.0
     @test GAz == 450.0
+
+    explicit_overrides_material = (
+        EA = [260.0, 520.0],
+        GAy = [100.0, 200.0],
+        GAz = [300.0, 500.0],
+        poisson_ratio = [-1.0, -1.0],
+        shear_correction = [0.0, 0.0],
+    )
+    GAy, GAz = OWENSFEA.transverseShearStiffness(explicit_overrides_material, N)
+    @test GAy == 175.0
+    @test GAz == 450.0
+
+    @test_throws ArgumentError OWENSFEA.transverseShearStiffness(
+        (EA = [260.0, 520.0], GAy = nothing, GAz = nothing, poisson_ratio = [-1.0, -1.0], shear_correction = [5 / 6, 5 / 6]),
+        N,
+    )
+    @test_throws ArgumentError OWENSFEA.transverseShearStiffness(
+        (EA = [260.0, 520.0], GAy = nothing, GAz = nothing, poisson_ratio = [0.3, 0.3], shear_correction = [0.0, 0.0]),
+        N,
+    )
 end
 
 @testset "Nonlinear selective stiffness guardrails" begin


### PR DESCRIPTION
## Summary
- add explicit section shear stiffness handling for GAy and GAz
- compute omitted transverse shear stiffness from EA, Poisson ratio, and shear-correction data instead of relying on a hidden hard-coded value
- document the section-property fields and pin constructor/helper behavior

Stacked on the OWENSFEA diagnostic branch. References #14 and #31.

## Tests
- julia --project=. test/HelperFunctions.jl

Note: local Julia emitted precompile warnings/errors for OffsetArrays/MbedTLS_jll extensions during startup, but the test file completed successfully.