### PR TITLE
Bump version for registration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OWENSFEA"
 uuid = "5906b1e7-6737-4278-91ec-d653c88addb4"
 authors = ["Kevin R. Moore <kevmoor@sandia.gov> and contributors"]
-version = "1.0.1"
+version = "1.0.2"
 
 [deps]
 ArnoldiMethod = "ec485272-7323-5ecc-a04f-4719b315124d"


### PR DESCRIPTION
## Summary
- bump OWENSFEA from `1.0.1` to `1.0.2`

## Why
Registrator rejected the current registration attempt because tag `v1.0.1` already exists and points to an older commit. A patch version bump lets the current master be registered without rewriting an existing tag.

## Verification
- `julia --project=. --startup-file=no -e 'using TOML; @assert VersionNumber(TOML.parsefile("Project.toml")["version"]) == v"1.0.2"; println("version ok")'`