### PR TITLE
Add section elastic-axis offset fields

### DIFF
--- a/src/structs.jl
+++ b/src/structs.jl
@@ -592,6 +592,8 @@ Struct with element sectional properties, each component is a 1x2 array with dis
 * `GAz::Union{Nothing,Array{<:float}}`: local-z transverse shear stiffness. When `nothing`, it is computed from `EA`, Poisson's ratio 0.3, and a 5/6 shear correction.
 * `poisson_ratio::Union{Nothing,Array{<:float}}`: Poisson's ratio used for default `GAy`/`GAz` when explicit shear stiffness is omitted.
 * `shear_correction::Union{Nothing,Array{<:float}}`: Timoshenko shear-correction factor used for default `GAy`/`GAz` when explicit shear stiffness is omitted.
+* `flapwiseEAOffset::Array{<:float}`: flapwise elastic-axis offset from legacy section-property inputs.
+* `edgewiseEAOffset::Array{<:float}`: edgewise elastic-axis offset from legacy section-property inputs.
 
 # Outputs:
 * `none`:
@@ -630,7 +632,23 @@ mutable struct SectionPropsArray
     GAz
     poisson_ratio
     shear_correction
+    flapwiseEAOffset
+    edgewiseEAOffset
 end
+
+function SectionPropsArray(
+    ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,
+    alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,
+    xaf,yaf,added_M22,added_M33,GAy,GAz,poisson_ratio,shear_correction,
+)
+    return SectionPropsArray(
+        ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,
+        alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,
+        xaf,yaf,added_M22,added_M33,GAy,GAz,poisson_ratio,shear_correction,
+        zero(rhoA),zero(rhoA),
+    )
+end
+
 SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset) = SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,nothing,nothing,zero(rhoA),zero(rhoA),nothing,nothing,nothing,nothing) #convenience function
 SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,xaf,yaf) = SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,xaf,yaf,zero(rhoA),zero(rhoA),nothing,nothing,nothing,nothing) #convenience function
 SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,xaf,yaf,added_M22,added_M33) = SectionPropsArray(ac,twist,rhoA,EIyy,EIzz,GJ,EA,rhoIyy,rhoIzz,rhoJ,zcm,ycm,a,EIyz,alpha1,alpha2,alpha3,alpha4,alpha5,alpha6,rhoIyz,b,a0,aeroCenterOffset,xaf,yaf,added_M22,added_M33,nothing,nothing,nothing,nothing) #convenience function

--- a/test/HelperFunctions.jl
+++ b/test/HelperFunctions.jl
@@ -49,6 +49,71 @@ end
     @test sum(p_N_x) == 0.0
 end
 
+@testset "SectionPropsArray elastic-axis offsets" begin
+    zeros2 = [0.0, 0.0]
+    rhoA = [1.0, 2.0]
+    base_args = (
+        zeros2,
+        zeros2,
+        rhoA,
+        fill(2.0, 2),
+        fill(3.0, 2),
+        fill(4.0, 2),
+        fill(5.0, 2),
+        fill(0.1, 2),
+        fill(0.2, 2),
+        fill(0.3, 2),
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        zeros2,
+        [2*pi, 2*pi],
+        zeros2,
+    )
+
+    legacy_short = OWENSFEA.SectionPropsArray(base_args...)
+    @test legacy_short.flapwiseEAOffset == zero(rhoA)
+    @test legacy_short.edgewiseEAOffset == zero(rhoA)
+
+    legacy_full = OWENSFEA.SectionPropsArray(
+        base_args...,
+        nothing,
+        nothing,
+        zero(rhoA),
+        zero(rhoA),
+        nothing,
+        nothing,
+        nothing,
+        nothing,
+    )
+    @test legacy_full.flapwiseEAOffset == zero(rhoA)
+    @test legacy_full.edgewiseEAOffset == zero(rhoA)
+
+    explicit_offsets = OWENSFEA.SectionPropsArray(
+        base_args...,
+        nothing,
+        nothing,
+        zero(rhoA),
+        zero(rhoA),
+        nothing,
+        nothing,
+        nothing,
+        nothing,
+        [0.11, 0.21],
+        [0.31, 0.41],
+    )
+    @test explicit_offsets.flapwiseEAOffset == [0.11, 0.21]
+    @test explicit_offsets.edgewiseEAOffset == [0.31, 0.41]
+end
+
 @testset "Element accumulation and assembly kernels" begin
     K = zeros(2, 3)
     OWENSFEA.calculateElement1!(2.0, 0.25, [1.0, 2.0], [3.0, 5.0, 7.0], K)


### PR DESCRIPTION
## Summary
- add flapwiseEAOffset and edgewiseEAOffset fields to SectionPropsArray for legacy section-property pass-through
- keep existing constructors backwards compatible by defaulting both offsets to zero(rhoA)
- add helper tests covering old constructor forms and explicit offset storage

## Tests
- julia --project=. test/HelperFunctions.jl
- git diff --check

Refs sandialabs/OWENS.jl#34