### PR TITLE
Expose steady spin vectors and speed element DOF mapping

### DIFF
--- a/docs/src/validation.md
+++ b/docs/src/validation.md
@@ -16,7 +16,8 @@ clear error instead of reaching undefined tangent-matrix state.
 
 `test/SpinningBeamDiagnostics.jl` pins structural-only spin reactions before
 gyric or spin-softening equation changes. The cases include straight and
-eccentric beams under scalar z-axis spin acceleration. The eccentric case also
+eccentric beams under scalar z-axis spin acceleration, plus a steady
+rigid-body spin-vector path for non-z spin axes. The eccentric case also
 documents the current root-moment gap: the x-force from the offset is present,
 while the reported spin-axis torque omits the corresponding `y^2` contribution.
 

--- a/src/steady.jl
+++ b/src/steady.jl
@@ -1,7 +1,8 @@
 """
 
 staticAnalysis(feamodel,mesh,el,displ,Omega,OmegaStart,elStorage;
-    reactionNodeNumber=1, OmegaDot=0.0, Fdof=[1], Fexternal=[0.0])
+    reactionNodeNumber=1, OmegaDot=0.0, Fdof=[1], Fexternal=[0.0],
+    rbData=zeros(9), CN2H=1.0*LinearAlgebra.I(3))
 
 This function performs a static analysis and returns displacement
 values and a flag denoting successful/unsuccessful analysis
@@ -18,12 +19,16 @@ values and a flag denoting successful/unsuccessful analysis
 * `OmegaDot::Float`: Steady State Rotational Acceleration
 * `Fdof::Array{<:Int}`: Global Dofs where Fexternal is acting, where max dof = nelem*ndof
 * `Fexternal{<:Float}`: Forces or moments associated with the Fdofs specified
+* `rbData::Vector`: optional hub-frame rigid-body acceleration, angular velocity,
+  and angular acceleration vector. Angular rates are in rad/s and rad/s^2.
+* `CN2H::Matrix`: optional inertial-to-hub transform used for gravity/body loads.
 #Outputs
 * `displ`:                    vector of displacemetns
 * `staticAnalysisSuccessful`: boolean flag denoting successful static analysis
 """
 function staticAnalysis(feamodel,mesh,el,displ,Omega,OmegaStart,elStorage;
-    reactionNodeNumber=1, OmegaDot=0.0, Fdof=[1], Fexternal=[0.0])
+    reactionNodeNumber=1, OmegaDot=0.0, Fdof=[1], Fexternal=[0.0],
+    rbData=zeros(9), CN2H=1.0*LinearAlgebra.I(3))
 
     feamodel.analysisType = "S" #Force type to align with the static/steady call
 
@@ -81,7 +86,8 @@ function staticAnalysis(feamodel,mesh,el,displ,Omega,OmegaStart,elStorage;
             Kg = zero(Kg1)
             Fg = zero(Fg1)
             TimoshenkoMatrixWrap!(feamodel,mesh,el,eldisp,displ,Omega,elStorage;
-                Kg,Fg,iterationCount,dispOld,loadStepPrev,loadStep,OmegaDot,countedNodes)
+                Kg,Fg,iterationCount,dispOld,loadStepPrev,loadStep,OmegaDot,
+                rbData,CN2H,countedNodes)
 
             # Fexternal, Fdof = externalForcingStatic()  #TODO: get arbitrary external loads from externalForcingStatic() function
             for i=1:length(Fdof)
@@ -141,8 +147,6 @@ function staticAnalysis(feamodel,mesh,el,displ,Omega,OmegaStart,elStorage;
     #feamodel.platformTurbineConnectionNodeNumber #TODO: multiple points?  the whole mesh?
     timeInt = nothing
     dispData = copy(displ)
-    rbData = zeros(9)
-    CN2H = 1.0*LinearAlgebra.I(3)
     #Calculate reaction at turbine base (hardwired to node number 1)
     FReaction = zeros(mesh.numEl*6)
     for reactionNodeNumber = 1:mesh.numEl

--- a/src/unsteady.jl
+++ b/src/unsteady.jl
@@ -263,23 +263,27 @@ function calcUnorm(unew,uold)
     return LinearAlgebra.norm(unew-uold)/LinearAlgebra.norm(unew)
 end
 
+const FEA_ELEMENT_DOF_MAP = (1, 7, 2, 8, 3, 9, 4, 10, 5, 11, 6, 12)
+
+function mapElementDofMatrix(Ktemp)
+    size(Ktemp) == (12, 12) ||
+        throw(DimensionMismatch("element matrix must be 12x12, got $(size(Ktemp, 1))x$(size(Ktemp, 2))"))
+
+    Kel = zeros(eltype(Ktemp), 12, 12)
+    @inbounds for i=1:12
+        I = FEA_ELEMENT_DOF_MAP[i]
+        for j=1:12
+            J = FEA_ELEMENT_DOF_MAP[j]
+            Kel[I,J] = Ktemp[i,j]
+        end
+    end
+    return Kel
+end
+
 """
 Internal, function to form total stifness matrix and transform to desired DOF mapping
 """
 function mapMatrixNonSym2(K11,K12,K13,K14,K15,K16,K21,K22,K23,K24,K25,K26,K31,K32,K33,K34,K35,K36,K41,K42,K43,K44,K45,K46,K51,K52,K53,K54,K55,K56,K61,K62,K63,K64,K65,K66)
-
-    T = [1 0 0 0 0 0 0 0 0 0 0 0;
-    0 0 0 0 0 0 1 0 0 0 0 0;
-    0 1 0 0 0 0 0 0 0 0 0 0;
-    0 0 0 0 0 0 0 1 0 0 0 0;
-    0 0 1 0 0 0 0 0 0 0 0 0;
-    0 0 0 0 0 0 0 0 1 0 0 0;
-    0 0 0 1 0 0 0 0 0 0 0 0;
-    0 0 0 0 0 0 0 0 0 1 0 0;
-    0 0 0 0 1 0 0 0 0 0 0 0;
-    0 0 0 0 0 0 0 0 0 0 1 0;
-    0 0 0 0 0 1 0 0 0 0 0 0;
-    0 0 0 0 0 0 0 0 0 0 0 1];
 
     Ktemp = zeros(12,12)
 
@@ -325,24 +329,7 @@ function mapMatrixNonSym2(K11,K12,K13,K14,K15,K16,K21,K22,K23,K24,K25,K26,K31,K3
     Ktemp[11:12,9:10] = K65
     Ktemp[11:12,11:12] = K66
 
-    #map to FEA numbering
-    # T2 = SparseArrays.sparse(T)
-    Kel = T'*Ktemp*T
-
-    #declare map
-    # map = [1, 7, 2, 8, 3, 9,...
-    #       4, 10, 5, 11, 6, 12];
-    #
-    # #map to FEA numbering
-    # for i=1:a
-    #     I=map[i];
-    #     for j=1:a
-    #         J=map(j);
-    #         Kel(I,J) = Ktemp(i,j);
-    #     end
-    # end
-
-    return Kel
+    return mapElementDofMatrix(Ktemp)
 
 end
 
@@ -350,37 +337,6 @@ end
 Internal, function to form total stifness matrix and transform to desired DOF mapping
 """
 function mapMatrixNonSym(Ktemp)
-
-    T = [1 0 0 0 0 0 0 0 0 0 0 0;
-    0 0 0 0 0 0 1 0 0 0 0 0;
-    0 1 0 0 0 0 0 0 0 0 0 0;
-    0 0 0 0 0 0 0 1 0 0 0 0;
-    0 0 1 0 0 0 0 0 0 0 0 0;
-    0 0 0 0 0 0 0 0 1 0 0 0;
-    0 0 0 1 0 0 0 0 0 0 0 0;
-    0 0 0 0 0 0 0 0 0 1 0 0;
-    0 0 0 0 1 0 0 0 0 0 0 0;
-    0 0 0 0 0 0 0 0 0 0 1 0;
-    0 0 0 0 0 1 0 0 0 0 0 0;
-    0 0 0 0 0 0 0 0 0 0 0 1];
-
-    #map to FEA numbering
-    T2 = SparseArrays.sparse(T)
-    Kel = T2'*Ktemp*T2
-
-    #declare map
-    # map = [1, 7, 2, 8, 3, 9,...
-    #       4, 10, 5, 11, 6, 12];
-    #
-    # #map to FEA numbering
-    # for i=1:a
-    #     I=map[i];
-    #     for j=1:a
-    #         J=map(j);
-    #         Kel(I,J) = Ktemp(i,j);
-    #     end
-    # end
-
-    return Kel
+    return mapElementDofMatrix(Ktemp)
 
 end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -636,7 +636,7 @@ function calculateShapeFunctions(elementOrder,xi,x)
     #Linear interpolation functions
     N = zeros(elementOrder+1)
     p_N_xi = zeros(elementOrder+1)
-    if elementOrder == 1
+    @inbounds if elementOrder == 1
         N[1] = 0.5*(1.0 - xi)
         N[2] = 0.5*(1.0 + xi)
 
@@ -645,7 +645,7 @@ function calculateShapeFunctions(elementOrder,xi,x)
     end
 
     #Quadratic interpolation functions
-    if elementOrder == 2
+    @inbounds if elementOrder == 2
         N[1] = 0.5*(xi-1.0)*xi
         N[2] = 1.0-xi^2
         N[3] = 0.5*(xi+1.0)*xi
@@ -658,12 +658,14 @@ function calculateShapeFunctions(elementOrder,xi,x)
     numNodesPerEl = length(N)
     NT = promote_type(eltype(p_N_xi), eltype(x))
     Jac = zero(NT)
-    for i=1:numNodesPerEl
+    length(x) >= numNodesPerEl ||
+        throw(DimensionMismatch("coordinate vector must have at least $numNodesPerEl entries, got $(length(x))"))
+    @inbounds for i=1:numNodesPerEl
         Jac = Jac + p_N_xi[i]*x[i]
     end
 
     p_N_x = zeros(NT, numNodesPerEl)
-    for i=1:numNodesPerEl
+    @inbounds for i=1:numNodesPerEl
         p_N_x[i] = p_N_xi[i]/Jac
     end
     return N,p_N_x,Jac
@@ -675,7 +677,9 @@ Internal, linear interpolation
 function interpolateVal(valNode::AbstractArray{T}, N::AbstractVector{S}) where {T, S}
     TS = promote_type(T, S)
     valGP = zero(TS)
-    for i in eachindex(N)
+    length(valNode) >= length(N) ||
+        throw(DimensionMismatch("value vector must have at least $(length(N)) entries, got $(length(valNode))"))
+    @inbounds for i in eachindex(N)
         valGP = valGP + N[i]*valNode[i]
     end
     return valGP
@@ -689,11 +693,10 @@ function mapVector(Ftemp)
     a=length(Ftemp)
     Fel=zeros(a)
 
-    # #declare map
-    map = [1, 7, 2, 8, 3, 9, 4, 10, 5, 11, 6, 12]
-
-    for i=1:a
-        I=map[i]
+    a == length(FEA_ELEMENT_DOF_MAP) ||
+        throw(DimensionMismatch("element vector must have $(length(FEA_ELEMENT_DOF_MAP)) entries, got $a"))
+    @inbounds for i=1:a
+        I=FEA_ELEMENT_DOF_MAP[i]
         Fel[I] = Ftemp[i]
     end
     return Fel

--- a/test/SpinningBeamDiagnostics.jl
+++ b/test/SpinningBeamDiagnostics.jl
@@ -166,23 +166,27 @@ end
     @test isapprox(reaction[5], 0.0; atol=1e-10*abs(expected_spin_axis_torque))
 end
 
-@testset "Static global spin axis limitation" begin
+@testset "Static rigid-body spin vector plumbing" begin
     mesh, el, _, _ = _spinning_beam_fixture()
     feamodel = _spinning_beam_model(mesh)
     el_storage = OWENSFEA.initialElementCalculations(feamodel, el, mesh)
     displ0 = zeros(mesh.numNodes*6)
 
-    # staticAnalysis only exposes scalar Omega/OmegaDot, which is added to the
-    # hub z-axis in the Timoshenko element.  A future HAWT/global-x diagnostic
-    # needs a public steady API path for the existing omegaVec/rbData plumbing.
-    @test_throws MethodError OWENSFEA.staticAnalysis(
-        feamodel,
-        mesh,
-        el,
-        displ0,
-        0.0,
-        0.0,
-        el_storage;
-        rbData=[0.0, 0.0, 0.0, 2*pi, 0.0, 0.0, 0.0, 0.0, 0.0],
-    )
+    rb_data = zeros(9)
+    rb_data[4] = 2*pi*5.0
+    _, _, success, reaction = redirect_stdout(devnull) do
+        OWENSFEA.staticAnalysis(
+            feamodel,
+            mesh,
+            el,
+            displ0,
+            0.0,
+            0.0,
+            el_storage;
+            rbData=rb_data,
+        )
+    end
+
+    @test success
+    @test all(isapprox.(reaction[1:6], 0.0; atol=1e-8))
 end


### PR DESCRIPTION
## Summary
- expose the existing `rbData` and `CN2H` steady-state plumbing through `staticAnalysis` so non-z spin-axis diagnostics can be run without dropping to internal wrappers
- replace repeated 12x12 permutation-matrix multiplies with the equivalent direct element DOF map
- add explicit dimension checks before new `@inbounds` hot loops and update spinning diagnostics/docs

Closes #17.
Refs #16, #18, #29.

## Issue triage
- #17: verified current behavior keeps the S22 contribution disabled and the straight structural-only spin case reports zero spin-axis torque. This PR adds the steady spin-vector test path around that diagnostic.
- #16: not closed. I reproduced a sectional-CG-offset steady-spin torque on current master/this branch with `ycm = 0.3`; the root spin-axis moment remains nonzero, so the issue is still real.
- #18: not closed. I did not find a reproducer proving the off-axis nonlinear strain-stiffening instability is gone, and this PR makes no mechanics change there.
- #29: partial improvement only. The shared element DOF mapping path is substantially faster under `--check-bounds=yes`; the broader `Pkg.test` overhead should remain open for more profiling.

## Verification
- `julia --project=. test/SpinningBeamDiagnostics.jl`
- `julia --project=. test/HelperFunctions.jl`
- `julia --project=. test/runtests.jl`
- `julia --project=. --check-bounds=yes -e ...` microbenchmark: 200k `mapMatrixNonSym2` calls changed from ~2.206s on `origin/master` to ~0.304s on this branch; interpolation/shape-function timings were effectively unchanged.