### PR TITLE
Reduce bounds-check overhead in modal assembly

### DIFF
--- a/src/modal.jl
+++ b/src/modal.jl
@@ -398,43 +398,60 @@ Internal, assembles the element matrix into the global system of equations
 * `Kg`:             global system matrix with assembled element
 """
 function assemblyMatrixOnly(Ke,conn,numNodesPerEl,numDOFPerNode,Kg)
-
-    count = 1
-    dofList = zeros(Int,numNodesPerEl*numDOFPerNode)
-    for i=1:numNodesPerEl
-        for j=1:numDOFPerNode
-            dofList[count] = (conn[i]-1)*numDOFPerNode + j
-            count = count +1
-        end
-    end
-
-    Kg[dofList,dofList] = Kg[dofList,dofList] + Ke
-    # numDOFPerEl = length(dofList)
-    # #Assemble element i into global system
-    #         for j=1:numDOFPerEl
-    #             J = dofList(j)
-    #             for m=1:numDOFPerEl
-    #                 M = dofList(m)
-    #                 Kg(J,M) = Kg(J,M) + Ke(j,m)
-    #             end
-    #         end
-
+    _assemblyMatrixOnly!(Ke,conn,numNodesPerEl,numDOFPerNode,Kg)
     return Kg
-
 end
 
 function assemblyMatrixOnly!(Ke,conn,numNodesPerEl,numDOFPerNode,Kg)
+    _assemblyMatrixOnly!(Ke,conn,numNodesPerEl,numDOFPerNode,Kg)
+end
+
+function _assemblyMatrixOnly!(Ke,conn,numNodesPerEl,numDOFPerNode,Kg)
+    numDOFPerEl = numNodesPerEl*numDOFPerNode
+    length(conn) >= numNodesPerEl ||
+        throw(DimensionMismatch("connectivity must have at least $numNodesPerEl entries, got $(length(conn))"))
+    size(Ke, 1) == numDOFPerEl && size(Ke, 2) == numDOFPerEl ||
+        throw(DimensionMismatch("element matrix must be $(numDOFPerEl)x$(numDOFPerEl), got $(size(Ke, 1))x$(size(Ke, 2))"))
 
     count = 1
-    dofList = zeros(Int,numNodesPerEl*numDOFPerNode)
-    for i=1:numNodesPerEl
+    dofList = zeros(Int,numDOFPerEl)
+    @inbounds for i=1:numNodesPerEl
         for j=1:numDOFPerNode
             dofList[count] = (conn[i]-1)*numDOFPerNode + j
-            count = count +1
+            count = count + 1
         end
     end
 
-    Kg[dofList,dofList] = Kg[dofList,dofList] + Ke
+    minDof = minimum(dofList)
+    maxDof = maximum(dofList)
+    minDof >= 1 || throw(DimensionMismatch("connectivity maps to non-positive global DOF $minDof"))
+    size(Kg, 1) >= maxDof && size(Kg, 2) >= maxDof ||
+        throw(DimensionMismatch("global matrix must include DOF $maxDof, got $(size(Kg, 1))x$(size(Kg, 2))"))
+
+    if _has_duplicate_nodes(conn,numNodesPerEl)
+        Kg[dofList,dofList] = Kg[dofList,dofList] + Ke
+    else
+        @inbounds for j=1:numDOFPerEl
+            J = dofList[j]
+            for m=1:numDOFPerEl
+                M = dofList[m]
+                Kg[J,M] = Kg[J,M] + Ke[j,m]
+            end
+        end
+    end
+    return nothing
+end
+
+function _has_duplicate_nodes(conn,numNodesPerEl)
+    @inbounds for i=2:numNodesPerEl
+        nodeI = conn[i]
+        for j=1:i-1
+            if nodeI == conn[j]
+                return true
+            end
+        end
+    end
+    return false
 end
 
 """

--- a/test/HelperFunctions.jl
+++ b/test/HelperFunctions.jl
@@ -140,11 +140,27 @@ end
     @test Fg_returned == Fg
     @test Kg_returned == Kg
 
+    Kg_matrix_only = zeros(8, 8)
+    OWENSFEA.assemblyMatrixOnly!(Ke, conn, 2, 2, Kg_matrix_only)
+    @test Kg_matrix_only == Kg
+    @test OWENSFEA.assemblyMatrixOnly(Ke, conn, 2, 2, zeros(8, 8)) == Kg
+
+    duplicate_conn = [1, 1]
+    duplicate_dofs = [1, 2, 1, 2]
+    Kg_duplicate_expected = zeros(2, 2)
+    Kg_duplicate_expected[duplicate_dofs,duplicate_dofs] = Kg_duplicate_expected[duplicate_dofs,duplicate_dofs] + Ke
+    Kg_duplicate = zeros(2, 2)
+    OWENSFEA.assemblyMatrixOnly!(Ke, duplicate_conn, 2, 2, Kg_duplicate)
+    @test Kg_duplicate == Kg_duplicate_expected
+
     @test_throws DimensionMismatch OWENSFEA.calculateElement1!(2.0, 0.25, [1.0, 2.0], [3.0, 5.0], zeros(1, 2))
     @test_throws DimensionMismatch OWENSFEA.calculateVec1!(4.0, 0.5, [2.0, 3.0], zeros(1))
     @test_throws DimensionMismatch OWENSFEA.assembly!(zeros(3, 4), Fe, conn, 2, 2, zeros(8, 8), zeros(8))
     @test_throws DimensionMismatch OWENSFEA.assembly!(Ke, Fe, [0, 4], 2, 2, zeros(8, 8), zeros(8))
     @test_throws DimensionMismatch OWENSFEA.assembly!(Ke, Fe, conn, 2, 2, zeros(7, 7), zeros(7))
+    @test_throws DimensionMismatch OWENSFEA.assemblyMatrixOnly!(zeros(3, 4), conn, 2, 2, zeros(8, 8))
+    @test_throws DimensionMismatch OWENSFEA.assemblyMatrixOnly!(Ke, [0, 4], 2, 2, zeros(8, 8))
+    @test_throws DimensionMismatch OWENSFEA.assemblyMatrixOnly!(Ke, conn, 2, 2, zeros(7, 7))
 end
 
 @testset "Mesh and orientation constructors normalize input types" begin


### PR DESCRIPTION
## Summary
- route matrix-only modal assembly through one checked helper
- use direct `@inbounds` accumulation for unique element connectivity to avoid submatrix copy/assignment overhead
- preserve the previous submatrix assignment behavior for duplicate node connectivity and add regression coverage for it

## Verification
- `git diff --check`
- `julia --project=. --startup-file=no --check-bounds=yes -e 'include("test/HelperFunctions.jl")'` passed, 324 tests
- `/usr/bin/time -p julia --project=. --startup-file=no --check-bounds=yes test/CantileverBeamRotatingModal.jl` passed, `real 56.46`
- `julia --project=/tmp/owens_downstream_pr42 --startup-file=no --check-bounds=yes -e 'include("/tmp/owens_downstream_pr42/test/SNL5MW_CACT_oneway_unit.jl")'` passed
- `/usr/bin/time -p julia --project=. --startup-file=no --check-bounds=yes test/runtests.jl` passed, `real 413.69`
- assembly microbench under `--check-bounds=yes`, 200k calls: old submatrix path `0.371s`, new unique-connectivity path `0.290s`, `1.28x` faster

Note: I tested a dense LAPACK full-spectrum modal eigensolver while working this issue, but dropped it because it changed OWENS.jl downstream modal outputs. The remaining bounds-check suite overhead is dominated by the GXBeam reference path in `test/UnsteadyBeam.jl` (`Time GXBeam: 168.67`, `Time OWENS: 84.65` in the local bounds-enabled run), so this PR keeps the fix limited to OWENSFEA-owned assembly behavior.

Fixes #29