### PR TITLE
Reduce FEA transient allocation hotspots

### DIFF
--- a/src/intermediate.jl
+++ b/src/intermediate.jl
@@ -5,7 +5,7 @@ function TimoshenkoMatrixWrap!(feamodel,mesh,el,eldisp,dispData,Omega,elStorage;
     eldispiter=zero(eldisp),rbData=zeros(9),CN2H=1.0*LinearAlgebra.I(3),delta_t=0.0,
     OmegaDot=0.0,displ_im1=zero(eldisp),displdot_im1=zero(eldisp),timeInt=nothing,
     displddot_im1=zero(eldisp),iterationCount=0,postprocess=false,elementNumber=1,
-    dispOld=nothing,loadStep = 1.0,loadStepPrev = 1.0,predef=nothing,countedNodes = [])
+    dispOld=nothing,loadStep = 1.0,loadStepPrev = 1.0,predef=nothing,countedNodes = Int[])
 
     x = mesh.x
     y = mesh.y
@@ -206,8 +206,8 @@ function TimoshenkoMatrixWrap!(feamodel,mesh,el,eldisp,dispData,Omega,elStorage;
         if el.rotationalEffects[i]!=1
             Omega = 0.0
             OmegaDot = 0.0
-    		omegaVec = zeros(3)
-    		omegaDotVec = zeros(3)
+            omegaVec = (0.0, 0.0, 0.0)
+            omegaDotVec = (0.0, 0.0, 0.0)
         end
 
         if aeroElasticOn #TODO: why are we doing this if it is done again within timoshenko?

--- a/src/steady.jl
+++ b/src/steady.jl
@@ -43,7 +43,7 @@ function staticAnalysis(feamodel,mesh,el,displ,Omega,OmegaStart,elStorage;
     # dispm1 = zeros(12) #declare type
     dispOld = copy(displ) #initialize scope
     staticAnalysisSuccessfulForLoadStep = false #initialize scope
-    countedNodes = [] #TODO:??
+    countedNodes = Int[] #TODO:??
 
     elementOrder = feamodel.elementOrder #extract element order from feamodel
     numNodesPerEl = elementOrder + 1 #do initialization
@@ -75,6 +75,9 @@ function staticAnalysis(feamodel,mesh,el,displ,Omega,OmegaStart,elStorage;
     eldisp = zeros(numNodesPerEl*numDOFPerNode)
     Kg1 = zeros(totalNumDOF,totalNumDOF)   #initialize global stiffness matrix
     Fg1 = zeros(totalNumDOF)             #initialize global force vector
+    jointTransform = feamodel.jointTransform
+    hasJointConstraintsFlag = hasJointConstraints(jointTransform)
+    bcEqidx = findall(x->x==-1,feamodel.BC.map)
     #.........................................................................
     while !staticAnalysisComplete && loadStepCount<maxNumLoadSteps
         # staticAnalysisSuccessful = false #initialize staticAnalysisSuccessful flag
@@ -100,8 +103,10 @@ function staticAnalysis(feamodel,mesh,el,displ,Omega,OmegaStart,elStorage;
             # Kg,_,_ = applyGeneralConcentratedTerms(Kg,Kg,Kg,feamodel.nodalTerms.concStiffGen,feamodel.nodalTerms.concMassGen,feamodel.nodalTerms.concDampGen)
 
             #APPLY BOUNDARY CONDITIONS
-            Kg = applyConstraints(Kg,feamodel.jointTransform) #modify global stiffness matrix for joint constraints using joint transform
-            Fg = applyConstraintsVec(Fg,feamodel.jointTransform) #modify global force vector for joint constraints using joint transform
+            if hasJointConstraintsFlag
+                Kg = applyConstraints(Kg,jointTransform) #modify global stiffness matrix for joint constraints using joint transform
+                Fg = applyConstraintsVec(Fg,jointTransform) #modify global force vector for joint constraints using joint transform
+            end
 
             if feamodel.BC.numpBC==0
                 @warn "No boundary conditions detected. Fully fixing DOFs at Node 1 to faciliate static solve."
@@ -109,24 +114,30 @@ function staticAnalysis(feamodel,mesh,el,displ,Omega,OmegaStart,elStorage;
                 feamodel.BC.pBC = [1 1 0; 1 2 0; 1 3 0;1 4 0;1 5 0;1 6 0];
             end
 
-            Kg,Fg = applyBC(Kg,Fg,feamodel.BC,numDOFPerNode)  #apply boundary conditions to global stiffness matrix and force vector
+            Kg,Fg = applyBC!(Kg,Fg,feamodel.BC,numDOFPerNode,bcEqidx)  #apply boundary conditions to global stiffness matrix and force vector
             dispOld = copy(displ)  #assign displacement vector from previous iteration
 
             if nlParams.iterationType == "NR"  #system solve, norm calculation for newton-raphson iteration
                 delta_displ = Kg\Fg
-                delta_displ = feamodel.jointTransform*delta_displ
+                if hasJointConstraintsFlag
+                    delta_displ = jointTransform*delta_displ
+                end
                 displ = displ + delta_displ
                 uNorm = calcUnorm(displ-delta_displ,displ)
             elseif nlParams.iterationType == "DI" #system solve, norm calculation for direct iteration
                 displ_last = copy(displ)
                 displ = Kg\Fg
-                displ = feamodel.jointTransform*displ
+                if hasJointConstraintsFlag
+                    displ = jointTransform*displ
+                end
                 uNorm = calcUnorm(displ_last,displ)
                 gamm = 0.5
                 displ = (1-gamm)*displ + gamm*displ_last
             else                                        #system solve for linear case
                 displ = Kg\Fg
-                displ = feamodel.jointTransform*displ
+                if hasJointConstraintsFlag
+                    displ = jointTransform*displ
+                end
                 uNorm = 0
             end
             iterationCount = iterationCount +1         #increment iteration count
@@ -151,7 +162,7 @@ function staticAnalysis(feamodel,mesh,el,displ,Omega,OmegaStart,elStorage;
     FReaction = zeros(mesh.numEl*6)
     for reactionNodeNumber = 1:mesh.numEl
         try
-            countedNodes = [] #TODO:??
+            countedNodes = Int[] #TODO:??
             FReaction[(reactionNodeNumber-1)*6+1:reactionNodeNumber*6] = calculateReactionForceAtNode(reactionNodeNumber,feamodel,mesh,el,elStorage,timeInt,dispData,displ,rbData,Omega,OmegaDot,CN2H,countedNodes)
         catch
             # This is where a joint is println(reactionNodeNumber)

--- a/src/timoshenko.jl
+++ b/src/timoshenko.jl
@@ -19,6 +19,23 @@ function optionalInterpolatedProperty(sectionProps, field::Symbol, N, default)
     return isnothing(value) ? default : interpolateVal(value, N)
 end
 
+@inline function _add_conc_load!(Fe, concLoad)
+    @inbounds for i=1:6
+        Fe[i] += concLoad[i,1]
+        Fe[i+6] += concLoad[i,2]
+    end
+    return Fe
+end
+
+function _without_conc_load(F, concLoad, scale=one(eltype(F)))
+    out = copy(F)
+    @inbounds for i=1:6
+        out[i] -= scale*concLoad[i,1]
+        out[i+6] -= scale*concLoad[i,2]
+    end
+    return out
+end
+
 """
     transverseShearStiffness(sectionProps, N) -> GAy, GAz
 
@@ -557,7 +574,6 @@ function calculateTimoshenkoElementNL(input,elStorage;predef=nothing)
 
     twistAvg_d = rollAngle + 0.5*(sectionProps.twist[1] + sectionProps.twist[2])
     lambda = calculateLambda(sweepAngle*pi/180.0,coneAngle*pi/180.0,twistAvg_d.*pi/180.0)
-    lambdaSlim = lambda[1:3,1:3]
 
     dispLocal = lambda*disp_iter
 
@@ -575,17 +591,13 @@ function calculateTimoshenkoElementNL(input,elStorage;predef=nothing)
     omegaDot_x=omegaDotVec[1]
     omegaDot_y=omegaDotVec[2]
     omegaDot_z = omegaDotVec[3] + OmegaDot
-    Ohub = [omega_x;omega_y;omega_z]
-    ODotHub = [omegaDot_x;omegaDot_y;omegaDot_z]
-    Oel = lambdaSlim*Ohub
-    ODotel = lambdaSlim*ODotHub
-    O1 = Oel[1]
-    O2 = Oel[2]
-    O3 = Oel[3]
+    O1 = lambda[1,1]*omega_x + lambda[1,2]*omega_y + lambda[1,3]*omega_z
+    O2 = lambda[2,1]*omega_x + lambda[2,2]*omega_y + lambda[2,3]*omega_z
+    O3 = lambda[3,1]*omega_x + lambda[3,2]*omega_y + lambda[3,3]*omega_z
 
-    O1dot = ODotel[1]
-    O2dot = ODotel[2]
-    O3dot = ODotel[3]
+    O1dot = lambda[1,1]*omegaDot_x + lambda[1,2]*omegaDot_y + lambda[1,3]*omegaDot_z
+    O2dot = lambda[2,1]*omegaDot_x + lambda[2,2]*omegaDot_y + lambda[2,3]*omegaDot_z
+    O3dot = lambda[3,1]*omegaDot_x + lambda[3,2]*omegaDot_y + lambda[3,3]*omegaDot_z
 
     if eltype(input.gravityOn) == Bool && input.gravityOn == true
         a_x_n = 0.0 #accelerations in inertial frame
@@ -607,11 +619,13 @@ function calculateTimoshenkoElementNL(input,elStorage;predef=nothing)
     a_y_body = accelVec[2]
     a_z_body = accelVec[3]
 
-    a_grav = CN2H*[a_x_n; a_y_n; a_z_n]
+    a_grav_1 = CN2H[1,1]*a_x_n + CN2H[1,2]*a_y_n + CN2H[1,3]*a_z_n
+    a_grav_2 = CN2H[2,1]*a_x_n + CN2H[2,2]*a_y_n + CN2H[2,3]*a_z_n
+    a_grav_3 = CN2H[3,1]*a_x_n + CN2H[3,2]*a_y_n + CN2H[3,3]*a_z_n
 
-    a_x = a_x_body + a_grav[1]
-    a_y = a_y_body + a_grav[2]
-    a_z = a_z_body + a_grav[3]
+    a_x = a_x_body + a_grav_1
+    a_y = a_y_body + a_grav_2
+    a_z = a_z_body + a_grav_3
 
 
     #Integration loop
@@ -680,24 +694,20 @@ function calculateTimoshenkoElementNL(input,elStorage;predef=nothing)
         #Calculate Centrifugal load vector and gravity load vector
         #eventually incorporate lambda into gp level to account for variable
         #twist
-        posLocal = lambdaSlim*[xgp;ygp;zgp]
-        xbarlocal = posLocal[1]
-        ybarlocal = posLocal[2]
-        zbarlocal = posLocal[3]
+        xbarlocal = lambda[1,1]*xgp + lambda[1,2]*ygp + lambda[1,3]*zgp
+        ybarlocal = lambda[2,1]*xgp + lambda[2,2]*ygp + lambda[2,3]*zgp
+        zbarlocal = lambda[3,1]*xgp + lambda[3,2]*ygp + lambda[3,3]*zgp
 
         fx = rhoA*a_x #let these loads be defined in the inertial frame
         fy = rhoA*a_y + added_M22*a_y_body
         fz = rhoA*a_z + added_M33*a_z_body
 
-        rvec = [ 0; ycm; zcm]
-
-        fi_hub = [fx;fy;fz]
-
-        disLoadgpLocal = lambdaSlim*fi_hub
-        cpskew= [0 -rvec[3] rvec[2]
-                rvec[3] 0 -rvec[1]
-                -rvec[2] rvec[1] 0]
-        disMomentgp = cpskew*disLoadgpLocal
+        disLoadgpLocal_1 = lambda[1,1]*fx + lambda[1,2]*fy + lambda[1,3]*fz
+        disLoadgpLocal_2 = lambda[2,1]*fx + lambda[2,2]*fy + lambda[2,3]*fz
+        disLoadgpLocal_3 = lambda[3,1]*fx + lambda[3,2]*fy + lambda[3,3]*fz
+        disMomentgp_1 = -zcm*disLoadgpLocal_2 + ycm*disLoadgpLocal_3
+        disMomentgp_2 = zcm*disLoadgpLocal_1
+        disMomentgp_3 = -ycm*disLoadgpLocal_1
 
         if preStress #stress-stiffening/pre-stress calculations
             calculateElement1!(Faxial,integrationFactor,p_N2_x,p_N2_x,SS22)
@@ -716,17 +726,17 @@ function calculateTimoshenkoElementNL(input,elStorage;predef=nothing)
         end
 
         #distributed/body force load calculations
-        f1 = rhoA*((O2^2 + O3^2)*xbarlocal - O1*O2*ybarlocal - O1*O3*zbarlocal + O3dot*ybarlocal - O2dot*zbarlocal) - disLoadgpLocal[1]
+        f1 = rhoA*((O2^2 + O3^2)*xbarlocal - O1*O2*ybarlocal - O1*O3*zbarlocal + O3dot*ybarlocal - O2dot*zbarlocal) - disLoadgpLocal_1
         calculateVec1!(f1,integrationFactor,N1,F1)
-        f2 = rhoA*((O1^2+O3^2)*ybarlocal - zbarlocal*O2*O3 - xbarlocal*O1*O2 + O1dot*zbarlocal - O3dot*xbarlocal) - disLoadgpLocal[2]
+        f2 = rhoA*((O1^2+O3^2)*ybarlocal - zbarlocal*O2*O3 - xbarlocal*O1*O2 + O1dot*zbarlocal - O3dot*xbarlocal) - disLoadgpLocal_2
         calculateVec1!(f2,integrationFactor,N2,F2)
-        f3 = sectionAeroLift + rhoA*((O1^2+O2^2)*zbarlocal - O3*O1*xbarlocal - O2*O3*ybarlocal + O2dot*xbarlocal - O1dot*ybarlocal) - disLoadgpLocal[3]
+        f3 = sectionAeroLift + rhoA*((O1^2+O2^2)*zbarlocal - O3*O1*xbarlocal - O2*O3*ybarlocal + O2dot*xbarlocal - O1dot*ybarlocal) - disLoadgpLocal_3
         calculateVec1!(f3,integrationFactor,N3,F3)
-        f4 = sectionAeroMoment + rhoA*(xbarlocal*(O1*O2*zcm - ycm*O1*O3)-ybarlocal*(ycm*O2*O3 + zcm*(O1^2+O3^2)) + zbarlocal*(ycm*(O1^2+O2^2)+zcm*O2*O3) + ycm*(O2dot*xbarlocal - O1dot*ybarlocal) - zcm*(O1dot*zbarlocal - O3dot*xbarlocal)) - disMomentgp[1]
+        f4 = sectionAeroMoment + rhoA*(xbarlocal*(O1*O2*zcm - ycm*O1*O3)-ybarlocal*(ycm*O2*O3 + zcm*(O1^2+O3^2)) + zbarlocal*(ycm*(O1^2+O2^2)+zcm*O2*O3) + ycm*(O2dot*xbarlocal - O1dot*ybarlocal) - zcm*(O1dot*zbarlocal - O3dot*xbarlocal)) - disMomentgp_1
         calculateVec1!(f4,integrationFactor,N4,F4)
-        f5 = rhoA*zcm*(xbarlocal*(O2^2+O3^2) - ybarlocal*O1*O2 - zbarlocal*O1*O3 - O2dot*zbarlocal + O3dot*ybarlocal) - disMomentgp[2]
+        f5 = rhoA*zcm*(xbarlocal*(O2^2+O3^2) - ybarlocal*O1*O2 - zbarlocal*O1*O3 - O2dot*zbarlocal + O3dot*ybarlocal) - disMomentgp_2
         calculateVec1!(f5,integrationFactor,N5,F5)
-        f6 = rhoA*ycm*((O1*O3*zbarlocal + O1*O2*ybarlocal)-(xbarlocal*(O2^2+O3^2)) - O3dot*ybarlocal + O2dot*zbarlocal) - disMomentgp[3]
+        f6 = rhoA*ycm*((O1*O3*zbarlocal + O1*O2*ybarlocal)-(xbarlocal*(O2^2+O3^2)) - O3dot*ybarlocal + O2dot*zbarlocal) - disMomentgp_3
         calculateVec1!(f6,integrationFactor,N6,F6)
 
         if aeroElasticOn && (bgp != 0) #aeroelastic calculations
@@ -1073,7 +1083,7 @@ function calculateTimoshenkoElementNL(input,elStorage;predef=nothing)
     Ce = Ce + CeRayleigh
 
     #compile element force vector
-    Fe = mapVector([F1;F2;F3;F4;F5;F6])
+    Fe = mapVector(F1,F2,F3,F4,F5,F6)
 
     # transform matrices for sweep
     # Note,a negative sweep angle, will sweep away from the direction of
@@ -1096,10 +1106,10 @@ function calculateTimoshenkoElementNL(input,elStorage;predef=nothing)
     ## Apply concentrated terms, including cross-coupling between concentrated mass and the other terms
     # TODO: should other cross-couplings be included here now since the off-diagonals can be included?
 
-    concMassFlag = !isempty(findall(x->x!=0,concMass))
-    concStiffFlag = !isempty(findall(x->x!=0,concStiff))
-    concDampFlag = !isempty(findall(x->x!=0,concDamp))
-    concLoadFlag = !isempty(findall(x->x!=0,concLoad))
+    concMassFlag = any(!iszero, concMass)
+    concStiffFlag = any(!iszero, concStiff)
+    concDampFlag = any(!iszero, concDamp)
+    concLoadFlag = any(!iszero, concLoad)
     if concMassFlag
         #modify Me for concentrated mass
         Me[1:6,1:6] += concMass[:,1:6]
@@ -1150,8 +1160,7 @@ function calculateTimoshenkoElementNL(input,elStorage;predef=nothing)
     end
 
     if concMassFlag || concLoadFlag
-        Fe[1:6] += concLoad[:,1]
-        Fe[7:12] += concLoad[:,2]
+        _add_conc_load!(Fe, concLoad)
 
         #modify Fe for  concentrated load
         Fe[1] += concMass[1,1]*(x[1]*(omega_y^2 + omega_z^2)-omega_x*omega_y*y[1] - omega_x*omega_z*z[1]) + concMass[1,1]*(y[1]*omegaDot_z-z[1]*omegaDot_y)  -  concMass[1,1]*a_x
@@ -1183,18 +1192,7 @@ function calculateTimoshenkoElementNL(input,elStorage;predef=nothing)
         Khate = Ke*a1 + a3.*Ce + Me
         Fhate = Fe*a4 + Me*(A) + Ke*(B) + Ce*(D)
 
-        FhatLessConc =   Fhate - [concLoad[1,1]
-        concLoad[2,1]
-        concLoad[3,1]
-        concLoad[4,1]
-        concLoad[5,1]
-        concLoad[6,1]
-        concLoad[1,2]
-        concLoad[2,2]
-        concLoad[3,2]
-        concLoad[4,2]
-        concLoad[5,2]
-        concLoad[6,2]].*a4
+        FhatLessConc = _without_conc_load(Fhate, concLoad, a4)
 
         #........................................................
 
@@ -1214,9 +1212,9 @@ function calculateTimoshenkoElementNL(input,elStorage;predef=nothing)
         a7 = timeInt.a7
         a8 = timeInt.a8
 
-        u=copy(disp)
-        udot=copy(dispdot)
-        uddot=copy(dispddot)
+        u=disp
+        udot=dispdot
+        uddot=dispddot
         if (iterationType=="NR")    #considerations if newton raphson iteration is used
             if (input.firstIteration)
                 A = a3*u + a4*udot + a5*uddot
@@ -1236,18 +1234,7 @@ function calculateTimoshenkoElementNL(input,elStorage;predef=nothing)
             Khate = Kehat + Khate
         end
 
-        FhatLessConc =   Fhate - [concLoad[1,1]
-        concLoad[2,1]
-        concLoad[3,1]
-        concLoad[4,1]
-        concLoad[5,1]
-        concLoad[6,1]
-        concLoad[1,2]
-        concLoad[2,2]
-        concLoad[3,2]
-        concLoad[4,2]
-        concLoad[5,2]
-        concLoad[6,2]]
+        FhatLessConc = _without_conc_load(Fhate, concLoad)
 
         #........................................................
 
@@ -1257,18 +1244,7 @@ function calculateTimoshenkoElementNL(input,elStorage;predef=nothing)
     end
 
     if (analysisType=="M")
-        FhatLessConc =   Fe - [concLoad[1,1]
-        concLoad[2,1]
-        concLoad[3,1]
-        concLoad[4,1]
-        concLoad[5,1]
-        concLoad[6,1]
-        concLoad[1,2]
-        concLoad[2,2]
-        concLoad[3,2]
-        concLoad[4,2]
-        concLoad[5,2]
-        concLoad[6,2]]
+        FhatLessConc = _without_conc_load(Fe, concLoad)
 
         if (iterationType=="DI")
             Fe = Fe*input.loadStep

--- a/src/unsteady.jl
+++ b/src/unsteady.jl
@@ -18,7 +18,7 @@ function initialElementCalculations(feamodel,el,mesh)
     #initial element calculation
     numNodesPerEl = 2
     numDOFPerNode = 6
-    countedNodes = []
+    countedNodes = Int[]
 
     elStorage = Array{ElStorage, 1}(undef, mesh.numEl)
     Tx = eltype(mesh.x)
@@ -48,7 +48,7 @@ function initialElementCalculations(feamodel,el,mesh)
         #get concentrated terms associated with element # TODO: This is redundant and can probably be cleaned up, and might mess up double counting?
         _, massConc, _, _, countedNodes = getElementConcTerms!(feamodel.nodalTerms.concStiff, feamodel.nodalTerms.concMass, feamodel.nodalTerms.concDamp, feamodel.nodalTerms.concLoad, mesh.conn[i, :], numDOFPerNode, countedNodes)
 
-        concMassFlag = !isempty(findall(x->x!=0,massConc))
+        concMassFlag = any(!iszero, massConc)
 
         Omega = 0.0
 
@@ -102,6 +102,9 @@ function  structuralDynamicsTransient(feamodel,mesh,el,dispData,Omega,OmegaDot,t
     numDOFPerNode = 6
 
     totalNumDOF = mesh.numNodes * numDOFPerNode
+    jointTransform = feamodel.jointTransform
+    hasJointConstraintsFlag = hasJointConstraints(jointTransform)
+    bcEqidx = findall(x->x==-1,feamodel.BC.map)
     eldisp = zeros(numNodesPerEl*numDOFPerNode)
     eldisp_sm1 = zeros(numNodesPerEl*numDOFPerNode)
     Kg1 = zeros(totalNumDOF,totalNumDOF) #initialize global stiffness and force vector
@@ -128,7 +131,7 @@ function  structuralDynamicsTransient(feamodel,mesh,el,dispData,Omega,OmegaDot,t
 
             Kg = zero(Kg1)
             Fg = zero(Fg1)
-            countedNodes = []
+            countedNodes = Int[]
             timeInt = TimoshenkoMatrixWrap!(feamodel,mesh,el,eldisp,
             dispData,Omega,elStorage;Kg,Fg,eldisp_sm1,eldispdot,eldispddot,eldispiter,rbData,CN2H,delta_t,
             OmegaDot,displ_im1,displdot_im1,displddot_im1,iterationCount,predef,countedNodes)
@@ -149,14 +152,18 @@ function  structuralDynamicsTransient(feamodel,mesh,el,dispData,Omega,OmegaDot,t
             end
 
             #------ apply constraints on system -----------------------------------
-            Kg = applyConstraints(Kg,feamodel.jointTransform)
-            Fg = applyConstraintsVec(Fg,feamodel.jointTransform)
+            if hasJointConstraintsFlag
+                Kg = applyConstraints(Kg,jointTransform)
+                Fg = applyConstraintsVec(Fg,jointTransform)
+            end
 
             #Apply BCs to global system
-            KgTotal,FgTotal = applyBC(Kg,Fg,feamodel.BC,numDOFPerNode)
+            KgTotal,FgTotal = applyBC!(Kg,Fg,feamodel.BC,numDOFPerNode,bcEqidx)
             solution = KgTotal\FgTotal  #solve for displacements
 
-            solution = feamodel.jointTransform*solution #transform to full dof listing
+            if hasJointConstraintsFlag
+                solution = jointTransform*solution #transform to full dof listing
+            end
 
             if feamodel.nlOn  #calculate norm between current iteration and last iteration
                 if iterationType=="NR"
@@ -198,7 +205,7 @@ function  structuralDynamicsTransient(feamodel,mesh,el,dispData,Omega,OmegaDot,t
         if analysisType != "stiff"
             for reactionNodeNumber = 1:mesh.numNodes
                 try
-                    countedNodes = [] #TODO:??
+                    countedNodes = Int[] #TODO:??
                     FReaction[(reactionNodeNumber-1)*6+1:reactionNodeNumber*6] = calculateReactionForceAtNode(reactionNodeNumber,feamodel,mesh,el,elStorage,timeInt,dispData,displ_im1,rbData,Omega,OmegaDot,CN2H,countedNodes)
                 catch
                     # This is where a joint is println(reactionNodeNumber)
@@ -256,6 +263,10 @@ function applyConstraintsVec(Fg,transMatrix)
     return transMatrix'*Fg
 end
 
+@inline function hasJointConstraints(transMatrix)
+    return size(transMatrix, 1) != size(transMatrix, 2)
+end
+
 """
 This function calculates a relative norm between two vectors: unew and uold
 """
@@ -285,7 +296,7 @@ Internal, function to form total stifness matrix and transform to desired DOF ma
 """
 function mapMatrixNonSym2(K11,K12,K13,K14,K15,K16,K21,K22,K23,K24,K25,K26,K31,K32,K33,K34,K35,K36,K41,K42,K43,K44,K45,K46,K51,K52,K53,K54,K55,K56,K61,K62,K63,K64,K65,K66)
 
-    Ktemp = zeros(12,12)
+    Ktemp = zeros(eltype(K11), 12, 12)
 
     Ktemp[1:2,1:2] = K11
     Ktemp[1:2,3:4] = K12

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -480,6 +480,7 @@ function createJointTransform(joint,numNodes,numDofPerNode)
     for i=1:aNumDof #loop over number of active DOFs
         jointTransform[reducedDOF[i],i] = 1.0 #mapping of active DOFs in full DOF list to reduced DOF list
     end
+    reducedDOFIndex = Dict{Int,Int}(reducedDOF[i] => i for i in eachindex(reducedDOF))
 
     #impose Tda portion of identity matrix and map to appropriate locations
 
@@ -497,8 +498,8 @@ function createJointTransform(joint,numNodes,numDofPerNode)
         Tda,dDOF,aDOF = createTda(jointType,slaveNodeNum,masterNodeNum,psi,theta,joint[i,:])
 
         for m=1:length(aDOF) #loop over global active DOFs associated with joint
+            entry = reducedDOFIndex[Int(aDOF[m])]
             for k = 1:length(dDOF) #loop over global dependent DOFs associated with joint
-                entry=findall(x->x==aDOF[m],reducedDOF)[1]  #determine reduced DOF associated with active DOF from original DOF listing
                 jointTransform[dDOF[k],entry] = Tda[k,m]  #map local joint transformation matrix (Tda) to entries in global transformation matrix (jointTransform)
             end
         end
@@ -698,6 +699,26 @@ function mapVector(Ftemp)
     @inbounds for i=1:a
         I=FEA_ELEMENT_DOF_MAP[i]
         Fel[I] = Ftemp[i]
+    end
+    return Fel
+end
+
+function mapVector(F1,F2,F3,F4,F5,F6)
+    NT = promote_type(eltype(F1), eltype(F2), eltype(F3), eltype(F4), eltype(F5), eltype(F6))
+    Fel = zeros(NT, 12)
+    @inbounds begin
+        Fel[1] = F1[1]
+        Fel[7] = F1[2]
+        Fel[2] = F2[1]
+        Fel[8] = F2[2]
+        Fel[3] = F3[1]
+        Fel[9] = F3[2]
+        Fel[4] = F4[1]
+        Fel[10] = F4[2]
+        Fel[5] = F5[1]
+        Fel[11] = F5[2]
+        Fel[6] = F6[1]
+        Fel[12] = F6[2]
     end
     return Fel
 end
@@ -1179,17 +1200,15 @@ load vector for a static analysis.
 
 """
 function applyBC(Kg,Fg,BC,numDofPerNode)
+    return applyBC!(copy(Kg),copy(Fg),BC,numDofPerNode)
+end
 
+function applyBC!(Kg,Fg,BC,numDofPerNode,eqidx=findall(x->x==-1,BC.map))
     numEq=size(Kg)[1]
-
-    #APPLY BCs FOR PRIMARY VARIABLE
-    Kg_bounded = copy(Kg)
-    Fg_bounded = copy(Fg)
 
     if (BC.numpBC > 0)
         pBC = BC.pBC
         numpBC = size(pBC)[1]
-        eqidx = findall(x->x==-1,BC.map)
         for i=1:numpBC
             nodeNumber = Int(pBC[i,1])
             dofNumber = Int(pBC[i,2])
@@ -1198,12 +1217,12 @@ function applyBC(Kg,Fg,BC,numDofPerNode)
             eqNumber = eqidx[i]#(nodeNumber-1)*numDofPerNode + dofNumber
 
             for j=1:numEq
-                Kg_bounded[eqNumber,j] = 0.0
-                Fg_bounded[j] = Fg_bounded[j] - Kg_bounded[j,eqNumber]*specVal
-                Kg_bounded[j,eqNumber] = 0.0
+                Kg[eqNumber,j] = 0.0
+                Fg[j] = Fg[j] - Kg[j,eqNumber]*specVal
+                Kg[j,eqNumber] = 0.0
             end
-            Fg_bounded[eqNumber] = specVal
-            Kg_bounded[eqNumber,eqNumber] = 1.0
+            Fg[eqNumber] = specVal
+            Kg[eqNumber,eqNumber] = 1.0
         end
     end
 
@@ -1224,7 +1243,7 @@ function applyBC(Kg,Fg,BC,numDofPerNode)
     #
     #     end
     # end
-    return Kg_bounded,Fg_bounded
+    return Kg,Fg
 end
 
 """
@@ -1337,24 +1356,24 @@ function findElementsAssociatedWithNodeNumber(nodeNum,conn,jointData)
         #first see if specified node is a slave node in a joint constraint
         # keep this here for future translation from matlab: res2 = find(ismember(jointData(:,3),nodeNum)) #search joint data slave nodes for node number
         #if it is, change it to the corresponding master node
-        if !isempty(findall(x->x==nodeNum,jointData[:,3]))
+        if any(x->x==nodeNum,jointData[:,3])
             nodeNum = jointData[end,2]
             if length(jointData)>1
                 error("Incorrect Joint Data and nodeNum, too many joints")
             end
         end
 
-        res1 = findall(x->x==nodeNum,jointData[:,2]) #search joint data master nodes for node number
-        if !isempty(res1)
-            jointNodeNumbers = jointData[res1,3]
-
-            for j=1:length(jointNodeNumbers) #loop over joints
+        for jointIndex in axes(jointData, 1)
+            if jointData[jointIndex, 2] == nodeNum
+                jointNodeNumber = jointData[jointIndex, 3]
                 for i=1:numEl
-                    localNodeNumber = findall(x->x==jointNodeNumbers[j],conn[i,:]) #finds indices of nodeNum in connectivity of element i #finds the local node number of element i that corresponds to nodeNum
-                    if !isempty(localNodeNumber) #assigns to an elementList and localNode list
-                        elList = vcat(elList,i)
-                        localNode = vcat(localNode,localNodeNumber[1])
-                        index = index + 1
+                    for localNodeNumber in axes(conn, 2)
+                        if conn[i, localNodeNumber] == jointNodeNumber
+                            push!(elList, i)
+                            push!(localNode, localNodeNumber)
+                            index = index + 1
+                            break
+                        end
                     end
                 end
             end
@@ -1365,11 +1384,13 @@ function findElementsAssociatedWithNodeNumber(nodeNum,conn,jointData)
 
 
     for i=1:numEl #loop over elements
-        localNodeNumber = findall(x->x==nodeNum,conn[i,:]) #finds indices of nodeNum in connectivity of element i #finds the local node number of element i that corresponds to nodeNum
-        if !isempty(localNodeNumber) #assigns to an elementList and localNode list
-            elList = vcat(elList,i)
-            localNode = vcat(localNode,localNodeNumber[1])
-            index = index + 1
+        for localNodeNumber in axes(conn, 2)
+            if conn[i, localNodeNumber] == nodeNum
+                push!(elList, i)
+                push!(localNode, localNodeNumber)
+                index = index + 1
+                break
+            end
         end
     end
 
@@ -1392,7 +1413,7 @@ function getElementConcTerms!(Kconc, Mconc, Cconc, Fconc, elNodes, numDOFPerNode
         elMconc1 = Mconc[(elNodes[1]-1)*numDOFPerNode+1:elNodes[1]*numDOFPerNode, (elNodes[1]-1)*numDOFPerNode+1:elNodes[1]*numDOFPerNode]
         elCconc1 = Cconc[(elNodes[1]-1)*numDOFPerNode+1:elNodes[1]*numDOFPerNode, (elNodes[1]-1)*numDOFPerNode+1:elNodes[1]*numDOFPerNode]
         elFconc1 = Fconc[(elNodes[1]-1)*numDOFPerNode+1:elNodes[1]*numDOFPerNode]
-        append!(appliedNodes, elNodes[1])
+        push!(appliedNodes, elNodes[1])
     end
 
     if elNodes[2] in appliedNodes
@@ -1405,7 +1426,7 @@ function getElementConcTerms!(Kconc, Mconc, Cconc, Fconc, elNodes, numDOFPerNode
         elMconc2 = Mconc[(elNodes[2]-1)*numDOFPerNode+1:elNodes[2]*numDOFPerNode, (elNodes[2]-1)*numDOFPerNode+1:elNodes[2]*numDOFPerNode]
         elCconc2 = Cconc[(elNodes[2]-1)*numDOFPerNode+1:elNodes[2]*numDOFPerNode, (elNodes[2]-1)*numDOFPerNode+1:elNodes[2]*numDOFPerNode]
         elFconc2 = Fconc[(elNodes[2]-1)*numDOFPerNode+1:elNodes[2]*numDOFPerNode]
-        append!(appliedNodes, elNodes[2])
+        push!(appliedNodes, elNodes[2])
     end
 
     elKconc = hcat(elKconc1, elKconc2)


### PR DESCRIPTION
Summary
- remove allocation-heavy concentrated-load vector construction in Timoshenko transient assembly
- skip identity joint-transform multiplies for unconstrained models
- add in-place BC application for steady/transient solve loops
- reduce vector mapping and node lookup allocations

Performance
- UnsteadyBeam OWENS section: 81.34s clean baseline -> 39.86s current (~2.04x faster)
- Full FEA transient print: 83.32s prior baseline -> 38.66s current (~2.15x faster)

Tests
- julia --project=. --startup-file=no -e 'using Pkg; Pkg.test()'\n- git diff --check