### PR TITLE
Fix spinning CG offset reaction torque

### DIFF
--- a/docs/src/validation.md
+++ b/docs/src/validation.md
@@ -16,10 +16,11 @@ clear error instead of reaching undefined tangent-matrix state.
 
 `test/SpinningBeamDiagnostics.jl` pins structural-only spin reactions before
 gyric or spin-softening equation changes. The cases include straight and
-eccentric beams under scalar z-axis spin acceleration, plus a steady
-rigid-body spin-vector path for non-z spin axes. The eccentric case also
-documents the current root-moment gap: the x-force from the offset is present,
-while the reported spin-axis torque omits the corresponding `y^2` contribution.
+eccentric beams under scalar z-axis spin acceleration, sectional-CG offsets
+under steady scalar z-axis spin, plus a steady rigid-body spin-vector path for
+non-z spin axes. The sectional-CG case verifies that rotating-frame inertial
+loads are evaluated at the center of mass so the offset force and offset moment
+cancel about the spin axis for steady spin.
 
 ## Acceptance Rules
 

--- a/src/timoshenko.jl
+++ b/src/timoshenko.jl
@@ -61,6 +61,13 @@ function transverseShearStiffness(sectionProps, N)
     return GAy, GAz
 end
 
+@inline function _rotating_frame_inertial_force(rhoA, O1, O2, O3, O1dot, O2dot, O3dot, x, y, z)
+    f1 = rhoA*((O2^2 + O3^2)*x - O1*O2*y - O1*O3*z + O3dot*y - O2dot*z)
+    f2 = rhoA*((O1^2 + O3^2)*y - O2*O3*z - O1*O2*x + O1dot*z - O3dot*x)
+    f3 = rhoA*((O1^2 + O2^2)*z - O1*O3*x - O2*O3*y + O2dot*x - O1dot*y)
+    return f1, f2, f3
+end
+
 """
     calculateTimoshenkoElementInitialRun(elementOrder,modalFlag,xloc,sectionProps,sweepAngle,coneAngle,rollAngle,aeroSweepAngle,x,y,z,concMassFlag,concMass,Omega)
 
@@ -725,18 +732,28 @@ function calculateTimoshenkoElementNL(input,elStorage;predef=nothing)
             sectionAeroMoment = sectionAeroLift*(acgp+agp)
         end
 
+        xcm_local = xbarlocal
+        ycm_local = ybarlocal + ycm
+        zcm_local = zbarlocal + zcm
+        inertiaLoad_1, inertiaLoad_2, inertiaLoad_3 = _rotating_frame_inertial_force(
+            rhoA, O1, O2, O3, O1dot, O2dot, O3dot, xcm_local, ycm_local, zcm_local,
+        )
+        inertiaMoment_1 = ycm*inertiaLoad_3 - zcm*inertiaLoad_2
+        inertiaMoment_2 = zcm*inertiaLoad_1
+        inertiaMoment_3 = -ycm*inertiaLoad_1
+
         #distributed/body force load calculations
-        f1 = rhoA*((O2^2 + O3^2)*xbarlocal - O1*O2*ybarlocal - O1*O3*zbarlocal + O3dot*ybarlocal - O2dot*zbarlocal) - disLoadgpLocal_1
+        f1 = inertiaLoad_1 - disLoadgpLocal_1
         calculateVec1!(f1,integrationFactor,N1,F1)
-        f2 = rhoA*((O1^2+O3^2)*ybarlocal - zbarlocal*O2*O3 - xbarlocal*O1*O2 + O1dot*zbarlocal - O3dot*xbarlocal) - disLoadgpLocal_2
+        f2 = inertiaLoad_2 - disLoadgpLocal_2
         calculateVec1!(f2,integrationFactor,N2,F2)
-        f3 = sectionAeroLift + rhoA*((O1^2+O2^2)*zbarlocal - O3*O1*xbarlocal - O2*O3*ybarlocal + O2dot*xbarlocal - O1dot*ybarlocal) - disLoadgpLocal_3
+        f3 = sectionAeroLift + inertiaLoad_3 - disLoadgpLocal_3
         calculateVec1!(f3,integrationFactor,N3,F3)
-        f4 = sectionAeroMoment + rhoA*(xbarlocal*(O1*O2*zcm - ycm*O1*O3)-ybarlocal*(ycm*O2*O3 + zcm*(O1^2+O3^2)) + zbarlocal*(ycm*(O1^2+O2^2)+zcm*O2*O3) + ycm*(O2dot*xbarlocal - O1dot*ybarlocal) - zcm*(O1dot*zbarlocal - O3dot*xbarlocal)) - disMomentgp_1
+        f4 = sectionAeroMoment + inertiaMoment_1 - disMomentgp_1
         calculateVec1!(f4,integrationFactor,N4,F4)
-        f5 = rhoA*zcm*(xbarlocal*(O2^2+O3^2) - ybarlocal*O1*O2 - zbarlocal*O1*O3 - O2dot*zbarlocal + O3dot*ybarlocal) - disMomentgp_2
+        f5 = inertiaMoment_2 - disMomentgp_2
         calculateVec1!(f5,integrationFactor,N5,F5)
-        f6 = rhoA*ycm*((O1*O3*zbarlocal + O1*O2*ybarlocal)-(xbarlocal*(O2^2+O3^2)) - O3dot*ybarlocal + O2dot*zbarlocal) - disMomentgp_3
+        f6 = inertiaMoment_3 - disMomentgp_3
         calculateVec1!(f6,integrationFactor,N6,F6)
 
         if aeroElasticOn && (bgp != 0) #aeroelastic calculations

--- a/test/SpinningBeamDiagnostics.jl
+++ b/test/SpinningBeamDiagnostics.jl
@@ -1,7 +1,7 @@
 using Test
 import OWENSFEA
 
-function _spinning_beam_fixture(; L=2.0, nelem=4, y_offset=0.0, stiffness_scale=1.0)
+function _spinning_beam_fixture(; L=2.0, nelem=4, y_offset=0.0, section_ycm=0.0, section_zcm=0.0, stiffness_scale=1.0)
     b = 0.05
     h = 0.02
     A = b*h
@@ -14,11 +14,11 @@ function _spinning_beam_fixture(; L=2.0, nelem=4, y_offset=0.0, stiffness_scale=
     J = Iyy + Izz
 
     rhoA = rho*A
-    zeros2 = [0.0, 0.0]
+    pair(value) = fill(value, 2)
     section_props = Array{OWENSFEA.SectionPropsArray, 1}(undef, nelem)
     for i = 1:nelem
         section_props[i] = OWENSFEA.SectionPropsArray(
-            zeros2, zeros2,
+            pair(0.0), pair(0.0),
             fill(rhoA, 2),
             fill(E*Iyy, 2),
             fill(E*Izz, 2),
@@ -27,11 +27,11 @@ function _spinning_beam_fixture(; L=2.0, nelem=4, y_offset=0.0, stiffness_scale=
             fill(rho*Iyy, 2),
             fill(rho*Izz, 2),
             fill(rho*J, 2),
-            zeros2, zeros2, zeros2, zeros2,
-            zeros2, zeros2, zeros2, zeros2, zeros2, zeros2,
-            zeros2, zeros2, zeros2, zeros2,
+            pair(section_zcm), pair(section_ycm), pair(0.0), pair(0.0),
+            pair(0.0), pair(0.0), pair(0.0), pair(0.0), pair(0.0), pair(0.0),
+            pair(0.0), pair(0.0), pair(0.0), pair(0.0),
             nothing, nothing,
-            zeros2, zeros2,
+            pair(0.0), pair(0.0),
             fill(G*A, 2),
             fill(G*A, 2),
         )
@@ -105,6 +105,26 @@ function _root_reaction(mesh, el; Omega=0.0, OmegaDot=0.0)
         )
     end
     return success, reaction[1:6]
+end
+
+@testset "Sectional CG offset steady-spin reactions" begin
+    section_ycm = 0.3
+    spin_hz = 5.0
+    mesh, el, rhoA, L = _spinning_beam_fixture(; section_ycm, stiffness_scale=1e6)
+    success, reaction = _root_reaction(mesh, el; Omega=spin_hz)
+
+    omega = 2*pi*spin_hz
+    expected_axial_reaction = -rhoA*omega^2*L^2/2
+    expected_side_reaction = -rhoA*omega^2*section_ycm*L
+    expected_moment_scale = abs(rhoA*omega^2*section_ycm*L^2)
+
+    @test success
+    @test isapprox(reaction[1], expected_axial_reaction; rtol=1e-3)
+    @test isapprox(reaction[2], expected_side_reaction; rtol=1e-3)
+    @test isapprox(reaction[3], 0.0; atol=1e-10*abs(expected_axial_reaction))
+    @test isapprox(reaction[4], 0.0; atol=1e-10*expected_moment_scale)
+    @test isapprox(reaction[5], 0.0; atol=1e-10*expected_moment_scale)
+    @test isapprox(reaction[6], 0.0; atol=1e-7*expected_moment_scale)
 end
 
 @testset "Eccentric spinning beam spin-acceleration reactions" begin


### PR DESCRIPTION
## Summary
- evaluate rotating-frame inertial section loads at the sectional center of mass instead of only the reference axis
- compute the sectional offset moment from that same inertial load so steady-spin offset forces cancel about the spin axis
- add a regression test for sectional ycm offset steady spin and update validation docs

Closes #16.

## Local verification
- julia --project=. test/SpinningBeamDiagnostics.jl
- julia --project=. -e 'using Pkg; Pkg.test()'
- git diff --check