### PR TITLE
Expand OWENSFEA documentation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,11 +5,16 @@ makedocs(;
     modules = [OWENSFEA],
     pages = [
         "Home" => "index.md",
-        "Quickstart" => "quickstart.md",
+        "Quick Start" => "quickstart.md",
+        "Test-backed Examples" => "examples.md",
         "Model Assembly" => "model_assembly.md",
         "Theory, Frames, and Units" => joinpath("theory", "frames_units.md"),
         "Validation and Testing" => "validation.md",
-        "API Reference" => joinpath("reference", "reference.md"),
+        "Developer Guide" => "developer_guide.md",
+        "Reference" => [
+            "API Map" => joinpath("reference", "reference.md"),
+            "Autodocs by Source" => joinpath("reference", "autodocs.md"),
+        ],
     ],
     sitename = "OWENSFEA.jl",
     authors = "Kevin R. Moore <kevmoor@sandia.gov>",

--- a/docs/src/developer_guide.md
+++ b/docs/src/developer_guide.md
@@ -1,0 +1,107 @@
+# Developer Guide
+
+```@meta
+CurrentModule = OWENSFEA
+```
+
+This guide is for changes to OWENSFEA internals, tests, and documentation.
+
+## Work From The Tests
+
+Read the relevant test before changing solver logic:
+
+| Area | Start with |
+| --- | --- |
+| shape functions, assembly, BCs, joints, nodal terms | `test/HelperFunctions.jl` |
+| modal frequencies and matrix export | `test/CantileverBeamModal.jl` |
+| static/nonlinear displacement and strain | `test/CantileverBeamDisplacement.jl` |
+| spin and rotating-frame reactions | `test/SpinningBeamDiagnostics.jl` |
+| swept rotating beams and Campbell trends | `test/CantileverBeamRotating*.jl` |
+| transient dynamics | `test/UnsteadyBeam.jl` |
+| reduced-order dynamics | `test/NonlinearROM.jl` |
+
+The tests are also the maintained example source. When adding docs, prefer a
+small excerpt or distilled pattern from a test over an unverified new example.
+
+## Numerical Contracts
+
+Treat these as first-class implementation constraints:
+
+- public displacement and force vectors use node-major six-DOF ordering;
+- `pBC` values are prescribed displacements/rotations, not penalty terms;
+- joint constraints are enforced through transform matrices;
+- section properties use SI units and two endpoint values per element;
+- mesh orientation fields are in degrees, while internal angular states are in
+  radians;
+- scalar `Omega`/`OmegaDot` are legacy z-axis rev/s inputs, while `rbData`
+  angular entries are rad/s vectors;
+- `rotationalEffects` controls whether an element receives spin terms;
+- generated matrices and output files should go to temporary paths in tests.
+
+Prefer explicit equations, transforms, and constraints over tuning penalties.
+If a change alters units, signs, nondimensionalization, load scaling, or state
+updates, add a small test that exposes the convention.
+
+## Solver Changes
+
+Before editing `steady.jl`, `unsteady.jl`, `intermediate.jl`, `rom.jl`, or
+`timoshenko.jl`, identify which path owns the behavior:
+
+| Path | Core files |
+| --- | --- |
+| element matrices and strains | `src/timoshenko.jl` |
+| assembly dispatch by analysis type | `src/intermediate.jl` |
+| static load stepping | `src/steady.jl` |
+| transient Newmark-beta/Dean integration | `src/unsteady.jl` |
+| modal state-space eigensolve | `src/modal.jl` |
+| reduced-order projection/integration | `src/rom.jl` |
+| maps, BCs, joints, concentrated terms, reactions | `src/utilities.jl` |
+
+Keep low-level utility tests exact and high-level physics tests tolerant enough
+to allow harmless numerical reordering. For modal changes, compare mode pairing
+and ordering carefully because state-space eigenvalues are paired.
+
+## Adding Public API
+
+Many useful functions are currently unexported. Before exporting another name:
+
+- add or update its docstring;
+- add it to the reference map if it is user-facing;
+- add a focused test for argument shape, units, and frame expectations;
+- avoid mutating [`FEAModel`](@ref) fields as a hidden side effect unless the
+  existing entry point already does so and the behavior is documented.
+
+If a function is only meant for package internals, keep it unexported and document
+it through the grouped autodocs rather than promoting it in examples.
+
+## Documentation Workflow
+
+Build docs from the package root:
+
+```bash
+julia --project=docs docs/make.jl
+```
+
+The docs project points `OWENSFEA` at the local package via `docs/Project.toml`,
+so the build should not require network access when dependencies are already
+instantiated.
+
+When adding examples:
+
+- use plain `julia` code blocks for longer examples that should not run during
+  docs build;
+- use `@example` only for short snippets that are cheap and deterministic;
+- include the source test file near every test-backed example;
+- avoid documenting a result unless it is actually asserted in tests or produced
+  by a checked script.
+
+## Review Checklist
+
+Before considering a solver or docs change complete:
+
+- run the narrow test or docs build that exercises the change;
+- inspect numerical outputs for units and sign consistency;
+- update captions/text when a result changes;
+- keep generated artifacts out of version control unless they are intentionally
+  tracked;
+- check `git status` and avoid reverting unrelated edits from other work.

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -1,0 +1,177 @@
+# Test-backed Examples
+
+```@meta
+CurrentModule = OWENSFEA
+```
+
+OWENSFEA.jl currently keeps its maintained examples in `test/` rather than in a
+separate `examples/` directory. The examples below are extracted from those
+tests and are the safest starting points for new documentation or regression
+cases.
+
+## Straight Cantilever Modal Analysis
+
+Source: `test/CantileverBeamModal.jl`
+
+This case builds a 0.5 m rectangular steel cantilever with 40 linear beam
+elements. The root node is fixed in all six DOFs, gravity is disabled, and the
+model runs [`modal`](@ref) with `analysisType = "M"`.
+
+The test checks three levels of behavior:
+
+- OWENSFEA frequencies are compared against GXBeam frequencies within 1 percent
+  for the first five paired modes.
+- The first three two-dimensional bending modes are compared against the
+  Euler-Bernoulli formula `sqrt(EI/(rho*A)) / (2*pi) * (k/L)^2`, where
+  `k = [1.875, 4.694, 7.855]`.
+- Setting `returnDynMatrices = true` writes a MAT file containing assembled and
+  boundary-condition-reduced stiffness, mass, and damping matrices.
+
+Minimal modal call pattern:
+
+```julia
+feamodel = OWENSFEA.FEAModel(;
+    analysisType = "M",
+    dataOutputFilename = "none",
+    joint,
+    gravityOn = false,
+    pBC,
+    numNodes = mesh.numNodes,
+)
+
+freq, damp = OWENSFEA.modal(feamodel, mesh, el)[1:2]
+```
+
+When comparing mode lists, remember that the state-space eigenvalues are paired.
+Several tests compare every other OWENSFEA frequency.
+
+## Static Cantilever Deflection And Strain
+
+Source: `test/CantileverBeamDisplacement.jl`
+
+This case reuses the 0.5 m cantilever and sweeps tip loads from `1e4` N to
+`1e5` N. It runs both linear and nonlinear OWENSFEA paths and compares against
+GXBeam plus analytical beam formulas.
+
+The linear analytical checks are:
+
+```julia
+tip_displacement = P * L^3 / (3 * E * Iyy)
+top_strain = P * x_from_tip * h / (2 * E * Iyy)
+```
+
+The test stores all strain channels from [`ElStrain`](@ref):
+
+- `epsilon_x`, `epsilon_y`, and `epsilon_z`;
+- `kappa_x`, `kappa_y`, and `kappa_z`.
+
+It compares `kappa_y * h / 2` against the top-fiber bending strain. This is a
+useful regression pattern when changing sign conventions or local element
+frames.
+
+## Transient Tip-load Response
+
+Source: `test/UnsteadyBeam.jl`
+
+The transient validation case uses a 60 m vertical cantilever, Newmark-beta
+analysis (`analysisType = "TNB"`), Rayleigh damping coefficients of `0.005`, and
+a sinusoidal tip force. Each step creates [`DispData`](@ref), runs
+[`structuralDynamicsTransient`](@ref), and feeds [`DispOut`](@ref) state back
+into the next step.
+
+The test compares root force and moment channels against GXBeam time histories.
+The current tolerances are intentionally broad and should be treated as
+regression diagnostics, not close physical validation.
+
+Skeleton step:
+
+```julia
+disp_data = OWENSFEA.DispData(u_s, udot_s, uddot_s, u_sm1)
+
+el_strain, disp_out, reaction = OWENSFEA.structuralDynamicsTransient(
+    feamodel,
+    mesh,
+    el,
+    disp_data,
+    Omega,
+    OmegaDot,
+    time,
+    delta_t,
+    el_storage,
+    Fexternal,
+    Fdof,
+    CN2H,
+    rbData,
+)
+
+u_s = disp_out.displ_sp1
+udot_s = disp_out.displdot_sp1
+uddot_s = disp_out.displddot_sp1
+```
+
+## Swept Rotating Beam
+
+Sources: `test/CantileverBeamRotating.jl` and
+`test/CantileverBeamRotatingModal.jl`
+
+These tests build a two-segment beam with a 45 degree sweep in the second
+segment. They exercise orientation, joint welding between beam segments,
+rotating-frame loads, nonlinear static spin-up, and Campbell-diagram mode
+tracking.
+
+Important details:
+
+- `mesh_beam` in `test/testdeps.jl` creates the welded two-segment mesh and the
+  joint row.
+- Rotating modal tests set `spinUpOn = true` and `nlOn = true` before calling
+  [`autoCampbellDiagram`](@ref).
+- `rotSpdArrayRPM = collect(0:1000:6000)` is converted to Hz for OWENSFEA and to
+  rad/s for the GXBeam branch.
+- The rotating modal test passes explicit `GAy` and `GAz` values so OWENSFEA and
+  GXBeam share the same transverse shear stiffness.
+
+Use this case when changing orientation transforms, spin terms, or
+`rotationalEffects`.
+
+## Reduced-order Transient Dynamics
+
+Source: `test/NonlinearROM.jl`
+
+The ROM test builds a straight aluminum cantilever, runs full nonlinear
+Newmark-beta dynamics, builds a reduced model with [`reducedOrderModel`](@ref),
+and compares [`structuralDynamicsTransientROM`](@ref) against the full nonlinear
+transient result.
+
+Pinned behavior:
+
+- the nonlinear full-order response differs measurably from the linear
+  full-order response;
+- the nonlinear ROM stays within 5 percent relative norm of the nonlinear
+  full-order tip history;
+- the final ROM tip displacement is within 5 percent relative tolerance and
+  `5e-5` absolute tolerance.
+
+This is the best maintained example for updating `DispData` with modal states:
+when using ROM, include `eta_s`, `etadot_s`, and `etaddot_s` in the next
+[`DispData`](@ref).
+
+## Utility Contracts
+
+Source: `test/HelperFunctions.jl`
+
+The helper tests are small enough to read before editing utility code. They pin:
+
+- Gauss quadrature points and weights from [`getGP`](@ref);
+- linear and quadratic shape functions from [`calculateShapeFunctions`](@ref);
+- type normalization in `Mesh` and [`Ort`](@ref);
+- default and explicit transverse shear stiffness;
+- assembly dimension checks;
+- joint dependent/active DOF maps;
+- concentrated nodal term parsing;
+- static boundary-condition application;
+- modal frequency extraction and reduced displacement reconstruction;
+- nonlinear selective-stiffness guardrails.
+
+If a future example needs to explain a low-level map or matrix operation, copy
+the smallest relevant pattern from this file rather than relying on a large
+coupled turbine case.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,9 +1,19 @@
-# OWENSFEA
+# OWENSFEA.jl
 
-OWENSFEA is the structural dynamics package in the OWENS toolkit. It provides
-beam finite-element models used for turbine blades, struts, towers, and coupled
-aeroelastic simulations. The code supports modal, nonlinear steady, transient,
-and reduced-order structural workflows.
+```@meta
+CurrentModule = OWENSFEA
+```
+
+OWENSFEA.jl is the structural finite-element package used by the OWENS wind
+energy toolkit. It models slender turbine components with Timoshenko beam
+elements and supplies structural states, strains, modal data, and reaction loads
+to higher-level OWENS workflows.
+
+The package is used most often for vertical-axis wind turbine structures, where
+spin softening, centrifugal stiffening, Coriolis terms, and rotating-frame
+reaction loads can matter. It can also be run as a structural-only beam solver
+for straight or swept cantilevers, modal validation cases, transient tip-load
+response, and reduced-order structural dynamics.
 
 ```@raw html
 <p align="center">
@@ -11,28 +21,42 @@ and reduced-order structural workflows.
 </p>
 ```
 
-The package is based on a Timoshenko beam formulation and the dynamic-system
+The implementation follows the Timoshenko beam formulation and dynamic-system
 work described in:
 
 Owens, B. C., "Theoretical Developments and Practical Aspects of Dynamic Systems
 in Wind Energy Applications," Ph.D. thesis, Texas A & M University, 2013.
 
-## What This Package Owns
+## Capabilities
 
-- structural mesh, element, section-property, and FEA model types;
-- joint constraints, prescribed boundary conditions, and concentrated nodal
-  terms;
-- element stiffness, mass, damping, gravity, spin, and follower-load
-  calculations;
-- linear modal analysis, nonlinear steady solve, transient dynamics, and ROM
-  utilities;
-- structural reactions, strains, and post-solve helper maps used by OWENS.
+| Workflow | Main entry points | Notes |
+| --- | --- | --- |
+| Modal analysis | [`modal`](@ref), [`autoCampbellDiagram`](@ref) | Linearized state-space eigenanalysis, optional spin-up preload, optional matrix export. |
+| Static/steady solve | [`staticAnalysis`](@ref) | Linear or nonlinear load-stepped solve with strains and nodal reactions. |
+| Transient dynamics | [`structuralDynamicsTransient`](@ref) | Newmark-beta (`"TNB"`) and Dean (`"TD"`) paths are selected through [`FEAModel`](@ref). |
+| Reduced-order dynamics | [`reducedOrderModel`](@ref), [`structuralDynamicsTransientROM`](@ref) | Modal reduction with stored spin, gyric, acceleration, and body-force coefficients. |
+| Assembly utilities | `Mesh`, [`SectionPropsArray`](@ref), [`El`](@ref), [`FEAModel`](@ref) | Mesh, section properties, boundary conditions, joints, and concentrated nodal terms. |
+
+## Package Boundaries
+
+OWENSFEA owns structural mesh data, element and section-property data,
+boundary-condition maps, joint transforms, concentrated nodal terms, element
+matrix assembly, structural solvers, strain recovery, and reaction-force
+postprocessing. Aerodynamic loading, turbine-level controls, and pre-processing
+of composite section data are normally handled by other OWENS packages before
+being mapped into OWENSFEA inputs.
+
+The maintained test suite is the best executable specification for the current
+behavior. The examples page summarizes those cases and points to the exact test
+files that pin the contracts.
 
 ## Where To Start
 
-- Use the quickstart for a minimal model and test-backed workflow references.
-- Use model assembly before changing meshes, joints, boundary conditions, or
-  concentrated terms.
-- Use the frames and units page before comparing against GXBeam, OpenFAST, or
-  experimental data.
-- Use the validation page before changing solver tolerances or reference data.
+- Use [Quick Start](@ref) for a minimal direct-constructor cantilever workflow.
+- Use [Test-backed Examples](@ref) to find maintained examples from the test
+  suite.
+- Use [Model Assembly](@ref) before changing mesh, joint, boundary-condition, or
+  concentrated-term inputs.
+- Use [Theory, Frames, and Units](@ref) before comparing OWENSFEA against
+  GXBeam, OpenFAST, analytical beam equations, or experiments.
+- Use [Developer Guide](@ref) before changing solver logic or extending the API.

--- a/docs/src/model_assembly.md
+++ b/docs/src/model_assembly.md
@@ -1,6 +1,26 @@
 # Model Assembly
 
+```@meta
+CurrentModule = OWENSFEA
+```
+
 This page documents the contracts that are easiest to break during refactors.
+
+## Required Objects
+
+Most workflows use the same four objects:
+
+| Object | Role |
+| --- | --- |
+| `Mesh` | Node coordinates, element connectivity, element types, segment metadata, and optional rotating/non-rotating metadata. |
+| [`SectionPropsArray`](@ref) | Two-point spanwise section properties for each element. |
+| [`El`](@ref) | Per-element section property, length, orientation, twist/roll, and rotational-effects flag arrays. |
+| [`FEAModel`](@ref) | Analysis type, boundary conditions, joints, nonlinear parameters, damping, gravity/spin flags, and nodal terms. |
+
+Create `Mesh`, `SectionPropsArray`, and `El` first, then construct
+[`FEAModel`](@ref) with `numNodes = mesh.numNodes`. The model constructor builds
+joint transforms, reduced-DOF maps, boundary-condition maps, and empty nodal
+term containers when those are not supplied.
 
 ## Mesh And Elements
 
@@ -8,6 +28,19 @@ This page documents the contracts that are easiest to break during refactors.
 segments, and optional structural blade/tower indexing. `El` stores element-level
 properties and distributed loads. Keep node ordering and element orientation
 stable because those choices define local beam frames and reaction signs.
+
+The maintained tests build straight and swept cantilever meshes directly in
+`test/testdeps.jl`. That helper computes element `Psi_d` and `Theta_d` from the
+node-to-node vector, stores lengths in `Ort.Length`, and uses joint rows to weld
+the two beam segments together.
+
+Element DOFs are node-major in public vectors:
+
+```text
+node i: ux, uy, uz, theta_x, theta_y, theta_z
+```
+
+For a node `n` and local DOF `d`, the global DOF is `(n - 1) * 6 + d`.
 
 ## Section Properties
 
@@ -31,12 +64,40 @@ workflows should pass explicit `GAy` and `GAz` values when available; otherwise
 they should pass the material Poisson ratio and shear-correction factor used to
 derive the transverse shear stiffnesses.
 
+The tests use two common section-property patterns:
+
+- rectangular-beam properties with `rhoA`, `EA`, `EIyy`, `EIzz`, `GJ`,
+  `rhoIyy`, `rhoIzz`, and `rhoJ` set from beam dimensions;
+- explicit `GAy` and `GAz` for rotating modal comparisons, so OWENSFEA and
+  GXBeam use the same transverse shear stiffness.
+
+Most properties are passed as two values per element endpoint and interpolated
+at quadrature points. Use SI units unless the caller's file parser clearly
+documents a conversion.
+
 ## Boundary Conditions
 
 Boundary conditions are expressed as node number, local DOF number, and
 prescribed value. Utility tests pin the reduced DOF map and static boundary
 condition application. A constrained DOF should either be removed from the solve
 or assigned the prescribed value consistently in the full displacement vector.
+
+Root-fixed cantilever tests use:
+
+```julia
+pBC = [
+    1 1 0
+    1 2 0
+    1 3 0
+    1 4 0
+    1 5 0
+    1 6 0
+]
+```
+
+`makeBCdata` builds [`BC_struct`](@ref) maps from this matrix, the reduced DOF
+list, and any joint transform. Static solves apply prescribed values directly
+with [`applyBC`](@ref); modal solves remove constrained rows/columns.
 
 ## Joints
 
@@ -66,6 +127,10 @@ The rigid-bar path couples slave translations to master rotations through the
 bar offset. Tests pin this transform because sign mistakes directly affect
 reaction forces.
 
+If a model has no joints, pass `zeros(0, 8)` or another zero-row matrix rather
+than a placeholder welded joint. The constructor accepts legacy placeholders,
+but explicit empty joint data is less ambiguous.
+
 ## Concentrated Terms
 
 `applyConcentratedTerms` parses concentrated mass, stiffness, damping, and load
@@ -75,3 +140,46 @@ ignore the second DOF in five-column input.
 
 Use temporary files for parser tests and prefer direct `data = ...` input for
 unit tests that only need to pin matrix assembly.
+
+Supported data tags are:
+
+| Tag | Meaning |
+| --- | --- |
+| `"M"` | diagonal concentrated mass |
+| `"K"` | diagonal concentrated stiffness |
+| `"C"` | diagonal concentrated damping |
+| `"F"` | concentrated nodal load |
+| `"M6"` | mass matrix entry with row/column DOFs |
+| `"K6"` | stiffness matrix entry with row/column DOFs |
+| `"C6"` | damping matrix entry with row/column DOFs |
+
+Example direct input from the helper-function tests:
+
+```julia
+nodalinputdata = Any[
+    1 "M" 2 1.5
+    1 "K" 3 2.5
+    1 "C" 4 3.5
+    1 "F" 5 4.5
+]
+
+nodal_terms = OWENSFEA.applyConcentratedTerms(1, 6; data = nodalinputdata)
+```
+
+## Analysis Types
+
+`FEAModel.analysisType` selects solver-side behavior:
+
+| Value | Use |
+| --- | --- |
+| `"M"` | modal analysis and linearized matrices |
+| `"S"` | internal static/steady path set by [`staticAnalysis`](@ref) |
+| `"TNB"` | Newmark-beta transient dynamics |
+| `"TD"` | Dean transient dynamics |
+| `"ROM"` | reduced-order transient dynamics |
+| `"stiff"` | pass-through structural path used by coupled workflows that do not solve FEA |
+| `"GX"` | GXBeam branch in [`autoCampbellDiagram`](@ref), not an OWENSFEA element solve |
+
+Use the entry-point function as the authority when possible. For example,
+[`staticAnalysis`](@ref) sets the model analysis type to `"S"` internally, and
+[`structuralDynamicsTransientROM`](@ref) sets it to `"ROM"`.

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -1,4 +1,8 @@
-# Quickstart
+# Quick Start
+
+```@meta
+CurrentModule = OWENSFEA
+```
 
 OWENSFEA workflows are easiest to debug when mesh, sections, boundary
 conditions, and loads are assembled explicitly. The cantilever tests provide the
@@ -10,7 +14,7 @@ smallest maintained examples:
 - `test/HelperFunctions.jl` for joint, boundary-condition, and nodal-term
   utility contracts.
 
-## Install
+## Install Or Develop
 
 ```julia
 using Pkg
@@ -28,23 +32,201 @@ Pkg.instantiate()
 The docs project uses local package sources and should be built with Julia 1.11
 or newer.
 
-## Minimal Structural Workflow
+## Minimal Cantilever Model
 
-1. Build or read a `Mesh`.
-2. Build an `El` object containing element-level material and section data.
-3. Create a `FEAModel` with analysis type, boundary conditions, joint data, and
-   solver options.
-4. Run the desired analysis path: modal, steady, unsteady, or ROM.
-5. Check displacement, strain, reaction, and modal outputs in the expected frame.
-
-The package exports selected utilities, but the high-level model types are often
-used through qualified names:
+The following is the smallest direct-constructor pattern used by the tests. It
+builds a straight cantilever with six degrees of freedom per node, fixed root
+boundary conditions, and constant Timoshenko section properties.
 
 ```julia
 import OWENSFEA
+using LinearAlgebra
 
-fea = OWENSFEA.FEAModel(; analysisType = "M", numNodes = 2)
+L = 0.5
+nelem = 8
+nnodes = nelem + 1
+num_dof_per_node = 6
+
+x = collect(range(0.0, L; length = nnodes))
+y = zeros(nnodes)
+z = zeros(nnodes)
+conn = hcat(collect(1:nelem), collect(2:nnodes))
+
+mesh = OWENSFEA.Mesh(
+    collect(1:nnodes),
+    nelem,
+    nnodes,
+    x,
+    y,
+    z,
+    collect(1:nelem),
+    conn,
+    zeros(Int, nelem),
+    [nelem],
+    zeros(1, 1),
+    zeros(Int, 1, 1),
+    zeros(Int, 1, 1),
+)
+
+width = 0.05
+height = 0.02
+area = width * height
+E = 2.1e11
+nu = 0.28
+G = E / (2 * (1 + nu))
+density = 7800.0
+Iyy = width * height^3 / 12
+Izz = width^3 * height / 12
+J = Iyy + Izz
+
+function constant_section()
+    zero2 = [0.0, 0.0]
+    GA = fill(5 / 6 * G * area, 2)
+    return OWENSFEA.SectionPropsArray(
+        zero2,
+        zero2,
+        fill(density * area, 2),
+        fill(E * Iyy, 2),
+        fill(E * Izz, 2),
+        fill(G * J, 2),
+        fill(E * area, 2),
+        fill(density * Iyy, 2),
+        fill(density * Izz, 2),
+        fill(density * J, 2),
+        zero2,
+        zero2,
+        zero2,
+        zero2,
+        zero2,
+        zero2,
+        zero2,
+        zero2,
+        zero2,
+        zero2,
+        zero2,
+        zero2,
+        zero2,
+        zero2,
+        nothing,
+        nothing,
+        zero2,
+        zero2,
+        GA,
+        GA,
+    )
+end
+
+section_props = [constant_section() for _ in 1:nelem]
+el = OWENSFEA.El(
+    section_props,
+    fill(L / nelem, nelem),
+    zeros(nelem),
+    zeros(nelem),
+    zeros(nelem),
+    ones(nelem),
+)
+
+pBC = [
+    1 1 0
+    1 2 0
+    1 3 0
+    1 4 0
+    1 5 0
+    1 6 0
+]
+joint = zeros(0, 8)
 ```
+
+The high-level model types are normally used through qualified names:
+
+```julia
+feamodel = OWENSFEA.FEAModel(;
+    analysisType = "M",
+    dataOutputFilename = "none",
+    joint,
+    pBC,
+    numNodes = mesh.numNodes,
+    gravityOn = false,
+    numModes = 8,
+)
+```
+
+## Modal Analysis
+
+```julia
+modal_result = OWENSFEA.modal(feamodel, mesh, el)
+freq = modal_result[1]
+damp = modal_result[2]
+first_mode_hz = freq[1]
+```
+
+`test/CantileverBeamModal.jl` compares this style of model against GXBeam and
+Euler-Bernoulli bending frequencies. The test extracts every other OWENSFEA
+state-space mode when comparing to GXBeam because the eigenvalues appear in
+conjugate pairs.
+
+## Static Tip Load
+
+```julia
+feamodel = OWENSFEA.FEAModel(;
+    analysisType = "TNB",
+    dataOutputFilename = "none",
+    joint,
+    pBC,
+    numNodes = mesh.numNodes,
+    nlOn = false,
+    gravityOn = false,
+    iterationType = "LINEAR",
+)
+
+el_storage = OWENSFEA.initialElementCalculations(feamodel, el, mesh)
+displ0 = zeros(mesh.numNodes * num_dof_per_node)
+tip_z_dof = (mesh.numNodes - 1) * num_dof_per_node + 3
+
+displ, strain, success, reaction = OWENSFEA.staticAnalysis(
+    feamodel,
+    mesh,
+    el,
+    displ0,
+    0.0,
+    0.0,
+    el_storage;
+    Fdof = [tip_z_dof],
+    Fexternal = [100.0],
+)
+```
+
+`staticAnalysis` returns the full displacement vector, element strain objects, a
+success flag, and reaction loads for each node/element slot used by the current
+implementation. For a cantilever sanity check, the linear tip deflection should
+scale with `P * L^3 / (3 * E * I)`.
+
+## Transient Step
+
+```julia
+disp_data = OWENSFEA.DispData(displ0, zero(displ0), zero(displ0), zero(displ0))
+dt = 0.002
+time = dt
+
+strain, disp_out, reaction = OWENSFEA.structuralDynamicsTransient(
+    feamodel,
+    mesh,
+    el,
+    disp_data,
+    0.0,
+    0.0,
+    time,
+    dt,
+    el_storage,
+    [100.0],
+    [tip_z_dof],
+    I(3),
+    zeros(9),
+)
+```
+
+For a time march, update [`DispData`](@ref) from `disp_out.displ_sp1`,
+`disp_out.displdot_sp1`, and `disp_out.displddot_sp1` before the next step.
 
 ## First Checks
 
@@ -53,6 +235,6 @@ Before trusting a result:
 - confirm the mesh has six structural degrees of freedom per node;
 - verify constrained DOF maps and joint transforms;
 - verify section properties are in SI units;
-- check whether rotations are radians internally or degrees in a file;
+- check whether rotations are radians internally or degrees at an IO boundary;
 - compare reactions and displacement signs against a hand calculation for a
   single-load case.

--- a/docs/src/reference/autodocs.md
+++ b/docs/src/reference/autodocs.md
@@ -1,0 +1,27 @@
+```@meta
+CurrentModule = OWENSFEA
+```
+
+# Autodocs by Source
+
+This page lists package docstrings. Prefer the [API Map](@ref) for a
+user-facing overview.
+
+## Source Groups
+
+- `structs.jl`: model data containers and constructors.
+- `modal.jl`: modal analysis, Campbell diagrams, and modal helpers.
+- `steady.jl`: static analysis and load stepping.
+- `unsteady.jl`: transient full-order dynamics and matrix mapping helpers.
+- `rom.jl`: reduced-order model generation and integration.
+- `timoshenko.jl`: element-level Timoshenko calculations.
+- `utilities.jl`: joints, BCs, assembly, concentrated terms, reactions, strains,
+  and shape functions.
+- `intermediate.jl`: analysis-type dispatch into element assembly.
+
+## Complete Autodocs
+
+```@autodocs
+Modules = [OWENSFEA]
+Order = [:type, :function]
+```

--- a/docs/src/reference/reference.md
+++ b/docs/src/reference/reference.md
@@ -2,13 +2,78 @@
 CurrentModule = OWENSFEA
 ```
 
+# API Map
+
+This page maps the main user-facing API. Complete docstrings are grouped by
+source file on [Autodocs by Source](@ref).
+
+## Model Data
+
+| Name | Purpose |
+| --- | --- |
+| [`FEAModel`](@ref) | Solver options, boundary conditions, joint transforms, nonlinear parameters, and nodal terms. |
+| `Mesh` | Node coordinates, connectivity, element type metadata, and structural indexing. |
+| [`Ort`](@ref) | Element orientation helper data. |
+| [`SectionPropsArray`](@ref) | Spanwise section stiffness, mass, offsets, aerodynamic helper fields, and shear stiffness inputs. |
+| [`El`](@ref) | Per-element section properties, lengths, angles, and rotational-effects flags. |
+| [`DispData`](@ref) | Displacement, velocity, acceleration, and previous-step state input. |
+| [`DispOut`](@ref) | Displacement, velocity, acceleration, and optional modal state output. |
+| [`ElStrain`](@ref) | Element strain and curvature channels. |
+| [`ROM`](@ref) | Reduced-order matrices and coefficient storage. |
+
+## Analysis Entry Points
+
+| Name | Purpose |
+| --- | --- |
+| [`modal`](@ref) | Linearized modal/state-space analysis. |
+| [`autoCampbellDiagram`](@ref) | RPM sweep for OWENSFEA or GXBeam modal frequencies. |
+| [`staticAnalysis`](@ref) | Static/steady displacement, strain, and reaction solve. |
+| [`initialElementCalculations`](@ref) | Cache initial element data before repeated analyses. |
+| [`structuralDynamicsTransient`](@ref) | Full-order transient structural dynamics. |
+| [`reducedOrderModel`](@ref) | Build reduced-order model matrices. |
+| [`structuralDynamicsTransientROM`](@ref) | Transient structural dynamics in reduced coordinates. |
+
+## Assembly And Mapping
+
+| Name | Purpose |
+| --- | --- |
+| [`createJointTransform`](@ref) | Build reduced/full DOF transform from joint rows. |
+| [`calculateReducedDOFVector`](@ref) | Build a reduced DOF list from constraints. |
+| [`constructReducedDispVectorMap`](@ref) | Build reduced displacement maps with BCs. |
+| [`calculateBCMap`](@ref) | Map prescribed BCs into equation numbering. |
+| [`applyBC`](@ref) | Apply static/transient prescribed boundary conditions. |
+| [`assembly!`](@ref) | Assemble element matrix/vector into global arrays. |
+| [`assemblyMatrixOnly`](@ref) | Assemble an element matrix without a load vector. |
+| [`applyConcentratedTerms`](@ref) | Parse concentrated mass, stiffness, damping, and load terms. |
+
+## Element And Postprocessing Helpers
+
+| Name | Purpose |
+| --- | --- |
+| [`defaultTransverseShearStiffness`](@ref) | Compute default Timoshenko transverse shear stiffness. |
+| [`transverseShearStiffness`](@ref) | Interpolate explicit or default shear stiffness at a quadrature point. |
+| [`calculateTimoshenkoElementInitialRun`](@ref) | Initial Timoshenko element calculation. |
+| [`calculateTimoshenkoElementNL`](@ref) | Nonlinear/current-state Timoshenko element calculation. |
+| [`calculateTimoshenkoElementStrain`](@ref) | Recover element strain channels. |
+| [`calculateTimoshenkoElementNLSS`](@ref) | Nonlinear selective-stiffness helper pinned by utility tests. |
+| [`calculateStructureMassProps`](@ref) | Integrate stored element mass properties. |
+| [`calculateReactionForceAtNode`](@ref) | Recover reaction load at a node. |
+| [`calculateStrainForElements`](@ref) | Recover strains for all elements. |
+| [`findElementsAssociatedWithNodeNumber`](@ref) | Locate element associations for a node. |
+| [`getGP`](@ref) | Gauss quadrature points and weights. |
+| [`calculateShapeFunctions`](@ref) | Linear/quadratic Lagrange shape functions and Jacobian. |
+
+## Load Stepping And Modal Helpers
+
+| Name | Purpose |
+| --- | --- |
+| [`updateLoadStep`](@ref) | Update static load-step state after an iteration. |
+| [`adaptiveLoadStepping`](@ref) | Adaptive load-step branch logic. |
+| [`applyBCModal`](@ref) | Remove constrained rows/columns for modal matrices. |
+| [`extractFreqDamp`](@ref) | Convert eigenpairs to frequency, damping, and normalized mode-shape data. |
+| [`constructReducedDispVecFromEigVec`](@ref) | Reconstruct reduced displacement vector from an eigenvector and BC map. |
+
 ## Index
 
 ```@index
-```
-
-## Types and functions
-
-```@autodocs
-Modules = [OWENSFEA]
 ```

--- a/docs/src/theory/frames_units.md
+++ b/docs/src/theory/frames_units.md
@@ -1,11 +1,60 @@
 # Theory, Frames, and Units
 
-## Beam Coordinates
+```@meta
+CurrentModule = OWENSFEA
+```
 
-OWENSFEA uses six degrees of freedom per node: three translations and three
-rotations. Element-level stiffness, mass, and load terms are assembled in local
-beam coordinates and mapped into the global system through element orientation
-data.
+## Element Mechanics
+
+OWENSFEA uses a Timoshenko beam formulation. Each node has six degrees of
+freedom:
+
+```text
+ux, uy, uz, theta_x, theta_y, theta_z
+```
+
+The element computes axial, bending, torsional, and transverse shear terms, plus
+mass, damping, gravity/body-load, spin, and concentrated-nodal contributions
+when those options are active. Element stiffness, mass, damping, and force terms
+are evaluated in local beam coordinates and assembled into the global structural
+system.
+
+The strain recovery path returns six channels per element through
+[`ElStrain`](@ref): `epsilon_x`, `epsilon_y`, `epsilon_z`, `kappa_x`,
+`kappa_y`, and `kappa_z`. The cantilever tests compare bending strain with
+`kappa_y * h / 2`, so changes to curvature signs should update tests and docs
+together.
+
+## Frames
+
+The mesh coordinates define the global structural frame used by public
+displacement and load vectors. Element orientation is carried by [`El`](@ref)
+fields:
+
+- `psi`: sweep angle about local/global 3-style orientation logic;
+- `theta`: cone/elevation angle;
+- `roll`: element roll or twist used by the element transform.
+
+The test helper `calculateElementOrientation` computes `Psi_d` and `Theta_d`
+from the vector from node 1 to node 2 and stores orientation angles in degrees.
+[`SectionPropsArray`](@ref) `twist` values are passed separately and are treated
+as section-property data, not mesh orientation metadata.
+
+Local section offsets such as `ycm` and `zcm` are local-section center-of-mass
+offsets. The spinning-beam diagnostics verify that steady rotating-frame
+inertial loads are evaluated at the center of mass so offset forces and moments
+balance correctly about the spin axis for the pinned cases.
+
+`CN2H` is the inertial-to-hub transform used by static and transient calls for
+gravity/body loads. The vector `rbData` uses:
+
+```text
+1:3  translational acceleration
+4:6  angular velocity
+7:9  angular acceleration
+```
+
+The angular entries in `rbData` are in rad/s and rad/s^2.
 
 ## Units
 
@@ -20,21 +69,36 @@ Use SI units unless a file format explicitly states otherwise:
 | moment | N m |
 | mass per unit length | kg/m |
 | internal angular speed | rad/s |
+| scalar `Omega` and `OmegaDot` inputs | rev/s and rev/s^2 |
 | bending stiffness | N m^2 |
 | torsional stiffness | N m^2 |
 | axial stiffness | N |
+| orientation angles in `Ort`/`El` | degrees |
+| section-property twist | radians |
 
 ## Rotations
 
-Internal rotations and angular velocities are in radians. Some mesh inputs,
-orientation helpers, and plots use degrees for readability; conversion should
-occur at the IO or plotting boundary.
+Internal displacement rotations and rigid-body angular velocities are in
+radians. Mesh orientation helpers and `Ort` fields use degrees for readability
+and legacy input compatibility. Convert at the IO boundary and keep internal
+solver state in radians.
+
+The public scalar `Omega` and `OmegaDot` arguments on modal/static/transient
+entry points are legacy z-axis spin values in revolutions/s and
+revolutions/s^2. The Timoshenko element path converts them internally to rad/s
+and rad/s^2 before adding them to the element rigid-body angular state. Use
+`rbData` when a full angular velocity or angular acceleration vector is needed.
 
 ## Loads
 
 Structural loads may be nodal, distributed per unit length, follower loads, or
 generalized reduced-order loads. Validation tests should name the load category
 because the expected reaction sign and magnitude differ.
+
+External point loads passed as `Fexternal` and `Fdof` use global DOF numbering.
+Concentrated nodal terms parsed by [`applyConcentratedTerms`](@ref) are stored
+on the model and included during element assembly. Distributed element loads are
+mapped through element transforms and shape functions.
 
 ## Gravity And Spin Terms
 
@@ -49,3 +113,39 @@ Timoshenko element path converts them internally to rad/s and rad/s^2 before
 adding them to the element rigid-body angular state. Global x-axis spin for HAWT
 rotor-only motion still needs an explicit public frame/state owner before it can
 replace the scalar z-axis path.
+
+`el.rotationalEffects[i] != 1` disables scalar and vector spin terms for element
+`i`. Use this for non-rotating tower or support elements in a mixed mesh.
+
+## Solver Flow
+
+Most workflows follow the same assembly path:
+
+1. [`FEAModel`](@ref) constructs joint transforms, reduced DOF lists, boundary
+   condition maps, nonlinear parameters, and default nodal terms.
+2. [`initialElementCalculations`](@ref) performs the first Timoshenko element
+   pass and caches element storage for reuse.
+3. `TimoshenkoMatrixWrap!` loops over elements, builds element inputs, calls the
+   Timoshenko element, and assembles global matrices/vectors.
+4. Joint constraints are applied with `jointTransform' * K * jointTransform` and
+   `jointTransform' * F` when constrained joints are present.
+5. Boundary conditions are applied by row/column modification for static and
+   transient solves, or by row/column removal for modal solves.
+6. The selected solver path computes displacements, eigenvalues, or reduced
+   modal coordinates.
+7. Strains and reaction forces are recovered after the solve.
+
+## Solver Paths
+
+| Path | Entry point | Main behavior |
+| --- | --- | --- |
+| Modal | [`modal`](@ref) | Assemble `K`, `M`, `C`, reduce for joints/BCs, build state-space matrix, solve eigenvalues, normalize mode shapes. |
+| Static | [`staticAnalysis`](@ref) | Apply load stepping, solve linear or nonlinear displacement updates, recover strain and reactions. |
+| Transient | [`structuralDynamicsTransient`](@ref) | Build an effective Newmark-beta or Dean system, iterate nonlinear displacements when enabled, update displacement/velocity/acceleration. |
+| ROM | [`reducedOrderModel`](@ref), [`structuralDynamicsTransientROM`](@ref) | Project full matrices into modal coordinates and time-integrate reduced states. |
+
+For nonlinear direct iteration (`"DI"`), the solver replaces the displacement
+state and optionally relaxes the update. For Newton-Raphson (`"NR"`), the solver
+uses displacement increments where that tangent path is implemented. Some
+low-level nonlinear selective-stiffness paths intentionally reject unsupported
+Newton-Raphson calls; those guardrails are pinned in `test/HelperFunctions.jl`.

--- a/docs/src/validation.md
+++ b/docs/src/validation.md
@@ -1,5 +1,9 @@
 # Validation and Testing
 
+```@meta
+CurrentModule = OWENSFEA
+```
+
 OWENSFEA has three useful test layers:
 
 | Layer | Test files | What is pinned |
@@ -22,6 +26,36 @@ non-z spin axes. The sectional-CG case verifies that rotating-frame inertial
 loads are evaluated at the center of mass so the offset force and offset moment
 cancel about the spin axis for steady spin.
 
+## Maintained Physical Checks
+
+| Check | Source | Expected behavior |
+| --- | --- | --- |
+| Straight cantilever modes | `test/CantileverBeamModal.jl` | OWENSFEA matches GXBeam modes within 1 percent and Euler-Bernoulli bending modes within 5 percent for the documented modes. |
+| Static tip deflection | `test/CantileverBeamDisplacement.jl` | Linear response follows `P * L^3 / (3 * E * Iyy)` and top-fiber bending strain follows the analytical beam relation. |
+| Swept rotating beam | `test/CantileverBeamRotating*.jl` | 45 degree swept-beam response and rotating modal trends stay close to GXBeam for the tested RPM range. |
+| Transient tip force | `test/UnsteadyBeam.jl` | Newmark-beta transient root force/moment channels stay inside current broad regression tolerances against GXBeam. |
+| Nonlinear ROM | `test/NonlinearROM.jl` | ROM tip history remains within 5 percent of the full nonlinear transient result for the maintained cantilever. |
+| Spin reactions | `test/SpinningBeamDiagnostics.jl` | Steady spin, spin acceleration, and center-of-mass offset reactions match hand-derived force and moment balances for pinned cases. |
+
+## Running Tests
+
+From the package root:
+
+```julia
+using Pkg
+Pkg.test()
+```
+
+Or from a shell:
+
+```bash
+julia --project -e 'using Pkg; Pkg.test()'
+```
+
+Some tests compare against GXBeam and can be slower than utility tests. When
+debugging a small utility change, run the specific included test file first,
+then run the full suite before merging.
+
 ## Acceptance Rules
 
 - Pin exact matrix entries for utility functions.
@@ -31,6 +65,8 @@ cancel about the spin axis for steady spin.
   against another solver.
 - Keep generated modal matrices and output files ignored or written to a
   temporary path.
+- Include units, frame, load direction, and enabled solver options in any new
+  physics test.
 
 ## Current Known Gaps
 
@@ -41,3 +77,5 @@ cancel about the spin axis for steady spin.
   agreement.
 - Several public-looking functions are unexported and need clearer docstrings
   before the API should be considered stable.
+- There is no separate `examples/` directory in this package at present; test
+  files are the maintained examples.


### PR DESCRIPTION
Summary:
- expands the package overview, quickstart, examples, model assembly, theory, validation, and developer guidance
- adds split reference/autodocs pages and updates Documenter navigation
- uses examples and expectations grounded in local tests and package APIs

Verification:
- julia --project=docs docs/make.jl passed
- git diff --check -- docs/make.jl docs/src passed